### PR TITLE
Asymmetric network test

### DIFF
--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -2,7 +2,6 @@
 ! Terms of use are as specified in LICENSE.txt
 module asymmetric_engine_test_m
   !! Define inference tests and procedures required for reporting results
-  use string_m, only : string_t
   use test_m, only : test_t
   use test_result_m, only : test_result_t
   use inference_engine_m, only : inference_engine_t
@@ -22,7 +21,7 @@ contains
 
   pure function subject() result(specimen)
     character(len=:), allocatable :: specimen
-    specimen = "An inference_engine_t representing XOR AND the left input" 
+    specimen = "An inference_engin_t object represening XOR-AND-the-2nd-input and using the default inference_strategy" 
   end function
 
   function results() result(test_results)
@@ -32,7 +31,7 @@ contains
       [ character(len=len("mapping (true,true) to false using the default ('do concurrent'/dot_product) inference method")) :: &
         "mapping (true,true) to false using the default ('do concurrent'/dot_product) inference method", &
         "mapping (false,true) to true using the default inference method", &
-        "mapping (true,false) to true using the default inference method", &
+        "mapping (true,false) to false using the default inference method", &
         "mapping (false,false) to false using the default inference method" &
       ], [xor_and_left_truth_table()] &
     )
@@ -46,15 +45,17 @@ contains
     integer, parameter :: neurons = 4 ! number of neurons per layer
     integer, parameter :: n_hidden = 2 ! number of hidden layers 
     integer i, j 
-    integer, parameter :: identity(*,*,*) = &
-      reshape([((merge(1,0,i==j), i=1,neurons), j=1,neurons)], shape=[neurons,neurons,n_hidden-1])
-   
+    real xor_into_neuron_2(neurons,neurons,n_hidden-1)
+    xor_into_neuron_2 = 0.
+    xor_into_neuron_2(1:3,2,1) = [1., -2., 1.]
+    xor_into_neuron_2(4,4,1) = 1.
+      
     inference_engine = inference_engine_t( &
-      input_weights = real(reshape([1,0,1,1,0,1,0,0], [n_in, neurons])), &
-      hidden_weights = real(identity), &
-      output_weights = real(reshape([1,-2,1,0], [n_out, neurons])), &
+      input_weights  = real(reshape([1,0,1,1,0,1,0,1], [n_in, neurons])), &
+      hidden_weights = xor_into_neuron_2, &
+      output_weights = real(reshape([0,1,0,1], [n_out, neurons])), &
       biases = reshape([0.,-1.99,0.,0., 0.,0.,0.,0.], [neurons, n_hidden]), &
-      output_biases = [0.] &
+      output_biases = [-1.] &
     )
   end function
 
@@ -76,7 +77,7 @@ contains
       )
         test_passes = [ &
           size(true_true)==1 .and. abs(true_true(1) - false) < tolerance, &
-          size(true_false)==1 .and. abs(true_false(1) - true) < tolerance,  &
+          size(true_false)==1 .and. abs(true_false(1) - false) < tolerance,  &
           size(false_true)==1 .and. abs(false_true(1) - true) < tolerance, &
           size(false_false)==1 .and. abs(false_false(1) - false) < tolerance  &
         ]

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -1,0 +1,88 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+module asymmetric_engine_test_m
+  !! Define inference tests and procedures required for reporting results
+  use string_m, only : string_t
+  use test_m, only : test_t
+  use test_result_m, only : test_result_t
+  use inference_engine_m, only : inference_engine_t
+  use matmul_m, only : matmul_t
+  implicit none
+
+  private
+  public :: asymmetric_engine_test_t
+
+  type, extends(test_t) :: asymmetric_engine_test_t
+  contains
+    procedure, nopass :: subject
+    procedure, nopass :: results
+  end type
+
+contains
+
+  pure function subject() result(specimen)
+    character(len=:), allocatable :: specimen
+    specimen = "An inference_engine_t representing XOR AND the left input" 
+  end function
+
+  function results() result(test_results)
+    type(test_result_t), allocatable :: test_results(:)
+
+    test_results = test_result_t( &
+      [ character(len=len("mapping (true,true) to false using the default ('do concurrent'/dot_product) inference method")) :: &
+        "mapping (true,true) to false using the default ('do concurrent'/dot_product) inference method", &
+        "mapping (false,true) to true using the default inference method", &
+        "mapping (true,false) to true using the default inference method", &
+        "mapping (false,false) to false using the default inference method" &
+      ], [xor_and_left_truth_table()] &
+    )
+  end function
+
+  function xor_and_left_network() result(inference_engine)
+
+    type(inference_engine_t) inference_engine
+    integer, parameter :: n_in = 2 ! number of inputs
+    integer, parameter :: n_out = 1 ! number of outputs
+    integer, parameter :: neurons = 4 ! number of neurons per layer
+    integer, parameter :: n_hidden = 2 ! number of hidden layers 
+    integer i, j 
+    integer, parameter :: identity(*,*,*) = &
+      reshape([((merge(1,0,i==j), i=1,neurons), j=1,neurons)], shape=[neurons,neurons,n_hidden-1])
+   
+    inference_engine = inference_engine_t( &
+      input_weights = real(reshape([1,0,1,1,0,1,0,0], [n_in, neurons])), &
+      hidden_weights = real(identity), &
+      output_weights = real(reshape([1,-2,1,0], [n_out, neurons])), &
+      biases = reshape([0.,-1.99,0.,0., 0.,0.,0.,0.], [neurons, n_hidden]), &
+      output_biases = [0.] &
+    )
+  end function
+
+  function xor_and_left_truth_table() result(test_passes)
+    logical, allocatable :: test_passes(:)
+
+    type(inference_engine_t) inference_engine
+
+    inference_engine = xor_and_left_network()
+
+    block
+      real, parameter :: tolerance = 1.E-08, false = 0., true = 1.
+
+      associate( &
+        true_true => inference_engine%infer(input=[true,true]), & 
+        true_false => inference_engine%infer(input=[true,false]), &
+        false_true => inference_engine%infer(input=[false,true]), &
+        false_false => inference_engine%infer(input=[false,false]) &
+      )
+        test_passes = [ &
+          size(true_true)==1 .and. abs(true_true(1) - false) < tolerance, &
+          size(true_false)==1 .and. abs(true_false(1) - true) < tolerance,  &
+          size(false_true)==1 .and. abs(false_true(1) - true) < tolerance, &
+          size(false_false)==1 .and. abs(false_false(1) - false) < tolerance  &
+        ]
+      end associate
+    end block
+
+  end function
+
+end module asymmetric_engine_test_m

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -21,7 +21,7 @@ contains
 
   pure function subject() result(specimen)
     character(len=:), allocatable :: specimen
-    specimen = "An inference_engin_t object represening XOR-AND-the-2nd-input and using the default inference_strategy" 
+    specimen = "An inference_engine_t object encoding an asymmetric (XOR-AND-the-2nd-input) network" 
   end function
 
   function results() result(test_results)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -33,11 +33,11 @@ contains
         "mapping (false,true) to true using the default inference method", &
         "mapping (true,false) to false using the default inference method", &
         "mapping (false,false) to false using the default inference method" &
-      ], [xor_and_left_truth_table()] &
+      ], [xor_and_2nd_input_truth_table()] &
     )
   end function
 
-  function xor_and_left_network() result(inference_engine)
+  function xor_and_2nd_input_network() result(inference_engine)
 
     type(inference_engine_t) inference_engine
     integer, parameter :: n_in = 2 ! number of inputs
@@ -59,12 +59,12 @@ contains
     )
   end function
 
-  function xor_and_left_truth_table() result(test_passes)
+  function xor_and_2nd_input_truth_table() result(test_passes)
     logical, allocatable :: test_passes(:)
 
     type(inference_engine_t) inference_engine
 
-    inference_engine = xor_and_left_network()
+    inference_engine = xor_and_2nd_input_network()
 
     block
       real, parameter :: tolerance = 1.E-08, false = 0., true = 1.

--- a/test/inference_engine_test_m.f90
+++ b/test/inference_engine_test_m.f90
@@ -6,9 +6,6 @@ module inference_engine_test_m
   use test_m, only : test_t
   use test_result_m, only : test_result_t
   use inference_engine_m, only : inference_engine_t
-  use activation_strategy_m, only : activation_strategy_t
-  use concurrent_dot_products_m, only : concurrent_dot_products_t
-  use step_m, only : step_t
   use matmul_m, only : matmul_t
   implicit none
 
@@ -66,6 +63,27 @@ contains
     )
   end function
 
+  function xor_matmul_network() result(inference_engine)
+
+    type(inference_engine_t) inference_engine
+    integer, parameter :: n_in = 2 ! number of inputs
+    integer, parameter :: n_out = 1 ! number of outputs
+    integer, parameter :: neurons = 3 ! number of neurons per layer
+    integer, parameter :: n_hidden = 2 ! number of hidden layers 
+    integer i, j 
+    integer, parameter :: identity(*,*,*) = &
+      reshape([((merge(1,0,i==j), i=1,neurons), j=1,neurons)], shape=[neurons,neurons,n_hidden-1])
+   
+    inference_engine = inference_engine_t( &
+      input_weights = real(reshape([1,0,1,1,0,1], [n_in, neurons])), &
+      hidden_weights = real(identity), &
+      output_weights = real(reshape([1,-2,1], [n_out, neurons])), &
+      biases = reshape([0.,-1.99,0., 0.,0.,0.], [neurons, n_hidden]), &
+      output_biases = [0.], &
+      inference_strategy = matmul_t() & 
+    )
+  end function
+
   function write_then_read() result(test_passes)
     logical, allocatable :: test_passes
 
@@ -119,7 +137,7 @@ contains
 
     type(inference_engine_t) inference_engine
    
-    inference_engine = xor_network()
+    inference_engine = xor_matmul_network()
 
     block
       real, parameter :: tolerance = 1.E-08, false = 0., true = 1.

--- a/test/main.f90
+++ b/test/main.f90
@@ -2,13 +2,16 @@
 ! Terms of use are as specified in LICENSE.txt
 program main
   use inference_engine_test_m, only : inference_engine_test_t  
+  use asymmetric_engine_test_m, only : asymmetric_engine_test_t  
   implicit none
 
   type(inference_engine_test_t) inference_engine_test
+  type(asymmetric_engine_test_t) asymmetric_engine_test
 
   integer :: passes=0, tests=0
 
   call inference_engine_test%report(passes, tests)
+  call asymmetric_engine_test%report(passes, tests)
 
   print *
   print '(*(a,:,g0))',"_________ In total, ",passes," of ",tests, " tests pass. _________"


### PR DESCRIPTION
This PR adds a unit test based on a neural network that behaves asymmetrically with regard to its two inputs.  The default `dot_product`-based neural network passes the new test.   The test exposes one failure in the `matmul`-based neural network that will be demonstrated in a second PR.