### PR TITLE
Fix handling of example-program input arguments in run-fpm.sh script

### DIFF
--- a/example/concurrent-inference.f90
+++ b/example/concurrent-inference.f90
@@ -24,7 +24,7 @@ program concurrent_inferences
 
   if (len(input_files)==0) then
     error stop new_line('a') // new_line('a') // &
-      'Usage: fpm run --example concurrent-inference -- --input-files "<space-delimited-list-of-files>"' 
+      'Usage: ./build/run-fpm.sh run --example concurrent-inference -- --input-files "<space-delimited-list-of-files>"' 
   end if
 
   print *,"Defining an array of inference_engine_t objects by reading the following files: ", input_files

--- a/example/construct-and-write.f90
+++ b/example/construct-and-write.f90
@@ -19,7 +19,7 @@ program construct_and_write
 
   if (len(output_file_name)==0) then
     error stop new_line('a') // new_line('a') // &
-      'Usage: fpm run --example construct-and-write -- --output-file "<file-name>"' 
+      'Usage: ./build/run-fpm.sh run --example construct-and-write -- --output-file "<file-name>"' 
   end if
 
   xor = inference_engine_t( &

--- a/example/read-and-query.f90
+++ b/example/read-and-query.f90
@@ -16,7 +16,7 @@ program read_and_query
 
   if (len(input_file_name)==0) then
     error stop new_line('a') // new_line('a') // &
-      'Usage: fpm run --example read-and-query -- --input-file "<file-name>"' 
+      'Usage: ./build/run-fpm.sh run --example read-and-query -- --input-file "<file-name>"' 
   end if
 
   print *,"Defining an inference_engine_t object by reading the file '"//input_file_name//"'"

--- a/scripts/run-fpm.sh-header
+++ b/scripts/run-fpm.sh-header
@@ -1,0 +1,21 @@
+#!/bin/sh
+#-- DO NOT EDIT -- created by inference-engine/setup.sh
+export PKG_CONFIG_PATH
+
+fpm_arguments=""
+program_arguments=""
+while test $# -gt 0
+do
+    case "$1" in
+        --) program_arguments="$@"
+            ;;
+        *) if [ -z "$program_arguments" ];  then
+             fpm_arguments="$fpm_arguments $1"
+           fi
+            ;;
+    esac
+    shift
+done
+
+/opt/homebrew/opt/fpm/bin/fpm $fpm_arguments \
+--profile debug \

--- a/scripts/run-fpm.sh-header
+++ b/scripts/run-fpm.sh-header
@@ -17,5 +17,3 @@ do
     shift
 done
 
-/opt/homebrew/opt/fpm/bin/fpm $fpm_arguments \
---profile debug \

--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,8 @@ fi
 export PKG_CONFIG_PATH
 cp scripts/run-fpm.sh-header build/run-fpm.sh
 RUN_FPM_SH="`realpath ./build/run-fpm.sh`"
+echo "`which fpm` \$fpm_arguments \\" >>  $RUN_FPM_SH
+echo "--profile debug \\" >> $RUN_FPM_SH
 echo "--c-compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_CC`\" \\" >> $RUN_FPM_SH
 echo "--compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FC`\" \\" >> $RUN_FPM_SH
 echo "--flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FLAG`\" \\"  >> $RUN_FPM_SH

--- a/setup.sh
+++ b/setup.sh
@@ -113,7 +113,7 @@ echo "INFERENCE_ENGINE_FPM_FLAG=\"$FPM_FLAG\""              >> $INFERENCE_ENGINE
 echo "Name: inference-engine"                               >> $INFERENCE_ENGINE_PC
 echo "Description: Inference Engine"                        >> $INFERENCE_ENGINE_PC
 echo "URL: https://github.com/berkeleylab/inference-engine" >> $INFERENCE_ENGINE_PC
-echo "Version: 0.1.0"                                       >> $INFERENCE_ENGINE_PC
+echo "Version: 0.1.1"                                       >> $INFERENCE_ENGINE_PC
 if [ $CI = true ]; then
   echo "---------------"
   echo "cat $INFERENCE_ENGINE_PC"
@@ -122,16 +122,13 @@ if [ $CI = true ]; then
 fi
 
 export PKG_CONFIG_PATH
+cp scripts/run-fpm.sh-header build/run-fpm.sh
 RUN_FPM_SH="`realpath ./build/run-fpm.sh`"
-echo "#!/bin/sh"                                                    >  $RUN_FPM_SH
-echo "#-- DO NOT EDIT -- created by inference-engine/install.sh"    >> $RUN_FPM_SH
-echo "export PKG_CONFIG_PATH"                                       >> $RUN_FPM_SH
-echo "`brew --prefix fpm`/bin/fpm \$@ \\"                 >> $RUN_FPM_SH
-echo "--profile debug \\"                                           >> $RUN_FPM_SH
-echo "--c-compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_CC`\" \\"  >> $RUN_FPM_SH
-echo "--compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FC`\" \\"    >> $RUN_FPM_SH
-echo "--flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FLAG`\" \\"      >> $RUN_FPM_SH
-echo "--link-flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_LD_FLAG`\"" >> $RUN_FPM_SH
+echo "--c-compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_CC`\" \\" >> $RUN_FPM_SH
+echo "--compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FC`\" \\" >> $RUN_FPM_SH
+echo "--flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FLAG`\" \\"  >> $RUN_FPM_SH
+echo "--link-flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_LD_FLAG`\" \\" >> $RUN_FPM_SH
+echo "\$program_arguments" >> $RUN_FPM_SH
 chmod u+x $RUN_FPM_SH
 if [ $CI = true ]; then
   echo "---------------"


### PR DESCRIPTION
With this PR, the following works:
```
./setup.sh
./build/run-fpm.sh run \
   --example <example-name> \
   -- --input-file <network-file-name>
```
Previously, example-program arguments such as in the final line above weren't handled properly by `run-fpm.sh`.