### PR TITLE
Make matmul the default Inference strategy

### DIFF
--- a/example/read-and-infer.f90
+++ b/example/read-and-infer.f90
@@ -11,6 +11,7 @@ program read_and_infer
   use inference_engine_m, only : inference_engine_t
   use string_m, only : string_t
   use sigmoid_m, only : sigmoid_t
+  use matmul_m, only : matmul_t
   implicit none
 
   type(inference_engine_t) inference_engine
@@ -25,7 +26,7 @@ program read_and_infer
   end if
 
   print *,"Defining an inference_engine_t object by reading the file '"//input_file_name//"'"
-  call inference_engine%read_network(string_t(input_file_name), sigmoid_t())
+  call inference_engine%read_network(string_t(input_file_name), sigmoid_t(), matmul_t())
 
   print *,"num_outputs = ", inference_engine%num_outputs()
   print *,"num_hidden_layers = ", inference_engine%num_hidden_layers()

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -51,11 +51,12 @@ module inference_engine_m
 
   interface
 
-    impure elemental module subroutine read_network(self, file_name, activation_strategy)
+    impure elemental module subroutine read_network(self, file_name, activation_strategy, inference_strategy)
       implicit none
       class(inference_engine_t), intent(out) :: self
       type(string_t), intent(in) :: file_name
       class(activation_strategy_t), intent(in), optional :: activation_strategy
+      class(inference_strategy_t), intent(in), optional :: inference_strategy
     end subroutine
 
     impure elemental module subroutine write_network(self, file_name)

--- a/src/inference_engine_s.f90
+++ b/src/inference_engine_s.f90
@@ -211,7 +211,11 @@ contains
       self%activation_strategy_  = step_t()
     end if
  
-    self%inference_strategy_  = concurrent_dot_products_t()
+    if (present(inference_strategy)) then
+      self%inference_strategy_  = inference_strategy
+    else
+      self%inference_strategy_  = concurrent_dot_products_t()
+    end if
 
     close(file_unit)
 

--- a/src/inference_engine_s.f90
+++ b/src/inference_engine_s.f90
@@ -3,7 +3,7 @@
 submodule(inference_engine_m) inference_engine_s
   use assert_m, only : assert
   use intrinsic_array_m, only : intrinsic_array_t
-  use concurrent_dot_products_m, only : concurrent_dot_products_t
+  use matmul_m, only : matmul_t
   use step_m, only : step_t
   implicit none
 
@@ -23,7 +23,7 @@ contains
     if (present(inference_strategy)) then
       inference_engine%inference_strategy_ = inference_strategy
     else
-      inference_engine%inference_strategy_ = concurrent_dot_products_t()
+      inference_engine%inference_strategy_ = matmul_t()
     end if
   end procedure
 
@@ -214,7 +214,7 @@ contains
     if (present(inference_strategy)) then
       self%inference_strategy_  = inference_strategy
     else
-      self%inference_strategy_  = concurrent_dot_products_t()
+      self%inference_strategy_  = matmul_t()
     end if
 
     close(file_unit)


### PR DESCRIPTION
Testing showed matmul to provide more accurate inference results matching the result of PyTorch to every significant digit.