### PR TITLE
More comprehensive unit testing

### DIFF
--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -41,10 +41,11 @@ contains
         "mapping (false,false) to false using the matmul inference strategy", &
         "counting the number of hidden layers", &
         "counting the number of neurons per layer", &
-        "counting the number of inputs" &
+        "counting the number of inputs", &
+        "counting the number of outputs" &
       ], &
       [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers(), &
-       test_neurons_per_layer(), test_num_inputs()] &
+       test_neurons_per_layer(), test_num_inputs(), test_num_outputs()] &
       
     )
   end function
@@ -98,6 +99,15 @@ contains
 
     inference_engine = xor_and_2nd_input_network()
     test_passes = inference_engine%num_inputs() == 2
+  end function
+
+  function test_num_outputs() result(test_passes)
+    logical test_passes
+
+    type(inference_engine_t) inference_engine
+
+    inference_engine = xor_and_2nd_input_network()
+    test_passes = inference_engine%num_outputs() == 1
   end function
 
   function xor_and_2nd_input_truth_table(inference_strategy) result(test_passes)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -38,8 +38,9 @@ contains
         "mapping (true,true) to false using the matmul inference strategy", &
         "mapping (true,false) to false using the matmul inference strategy", &
         "mapping (false,true) to true using the matmul inference strategy", &
-        "mapping (false,false) to false using the matmul inference strategy" &
-      ], [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t())] &
+        "mapping (false,false) to false using the matmul inference strategy", &
+        "counting the number of hidden layers" &
+      ], [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers()] &
     )
   end function
 
@@ -65,6 +66,15 @@ contains
       output_biases = [real(rkind):: -1.], &
       inference_strategy = inference_strategy &
     )
+  end function
+
+  function test_num_hidden_layers() result(test_passes)
+    logical, allocatable :: test_passes(:)
+
+    type(inference_engine_t) inference_engine
+
+    inference_engine = xor_and_2nd_input_network()
+    test_passes = [ inference_engine%num_hidden_layers() == 1 ]
   end function
 
   function xor_and_2nd_input_truth_table(inference_strategy) result(test_passes)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -70,21 +70,21 @@ contains
   end function
 
   function test_num_hidden_layers() result(test_passes)
-    logical, allocatable :: test_passes(:)
+    logical, allocatable :: test_passes
 
     type(inference_engine_t) inference_engine
 
     inference_engine = xor_and_2nd_input_network()
-    test_passes = [ inference_engine%num_hidden_layers() == 1 ]
+    test_passes = inference_engine%num_hidden_layers() == 1
   end function
 
   function test_neurons_per_layer() result(test_passes)
-    logical, allocatable :: test_passes(:)
+    logical, allocatable :: test_passes
 
     type(inference_engine_t) inference_engine
 
     inference_engine = xor_and_2nd_input_network()
-    test_passes = [ inference_engine%neurons_per_layer() == 4 ]
+    test_passes = inference_engine%neurons_per_layer() == 4
   end function
 
   function xor_and_2nd_input_truth_table(inference_strategy) result(test_passes)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -39,8 +39,9 @@ contains
         "mapping (true,false) to false using the matmul inference strategy", &
         "mapping (false,true) to true using the matmul inference strategy", &
         "mapping (false,false) to false using the matmul inference strategy", &
-        "counting the number of hidden layers" &
-      ], [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers()] &
+        "counting the number of hidden layers", &
+        "counting the number of neurons per layer" &
+      ], [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers(), test_neurons_per_layer()] &
     )
   end function
 
@@ -75,6 +76,15 @@ contains
 
     inference_engine = xor_and_2nd_input_network()
     test_passes = [ inference_engine%num_hidden_layers() == 1 ]
+  end function
+
+  function test_neurons_per_layer() result(test_passes)
+    logical, allocatable :: test_passes(:)
+
+    type(inference_engine_t) inference_engine
+
+    inference_engine = xor_and_2nd_input_network()
+    test_passes = [ inference_engine%neurons_per_layer() == 4 ]
   end function
 
   function xor_and_2nd_input_truth_table(inference_strategy) result(test_passes)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -40,8 +40,12 @@ contains
         "mapping (false,true) to true using the matmul inference strategy", &
         "mapping (false,false) to false using the matmul inference strategy", &
         "counting the number of hidden layers", &
-        "counting the number of neurons per layer" &
-      ], [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers(), test_neurons_per_layer()] &
+        "counting the number of neurons per layer", &
+        "counting the number of inputs" &
+      ], &
+      [xor_and_2nd_input_truth_table(), xor_and_2nd_input_truth_table(matmul_t()), test_num_hidden_layers(), &
+       test_neurons_per_layer(), test_num_inputs()] &
+      
     )
   end function
 
@@ -85,6 +89,15 @@ contains
 
     inference_engine = xor_and_2nd_input_network()
     test_passes = inference_engine%neurons_per_layer() == 4
+  end function
+
+  function test_num_inputs() result(test_passes)
+    logical, allocatable :: test_passes
+
+    type(inference_engine_t) inference_engine
+
+    inference_engine = xor_and_2nd_input_network()
+    test_passes = inference_engine%num_inputs() == 2
   end function
 
   function xor_and_2nd_input_truth_table(inference_strategy) result(test_passes)

--- a/test/asymmetric_engine_test_m.f90
+++ b/test/asymmetric_engine_test_m.f90
@@ -75,7 +75,7 @@ contains
   end function
 
   function test_num_hidden_layers() result(test_passes)
-    logical, allocatable :: test_passes
+    logical test_passes
 
     type(inference_engine_t) inference_engine
 
@@ -84,7 +84,7 @@ contains
   end function
 
   function test_neurons_per_layer() result(test_passes)
-    logical, allocatable :: test_passes
+    logical test_passes
 
     type(inference_engine_t) inference_engine
 
@@ -93,7 +93,7 @@ contains
   end function
 
   function test_num_inputs() result(test_passes)
-    logical, allocatable :: test_passes
+    logical test_passes
 
     type(inference_engine_t) inference_engine
 


### PR DESCRIPTION
What is Changing
------------------

This PR adds unit tests for the following `inference_engine_t` type-bound procedures:

* `num_inputs()`
* `num_outputs()`
* `neurons_per_layer()`
* `num_hidden_layers()`

Why It is Changing
-------------------
Having more fine-grained unit tests lays the groundwork for an upcoming refactoring that will eliminate the need for the `transpose()` invocations inside the `inference_engine_t` `infer` type-bound procedure.   The plan is to store weights in a transposed format upon construction of an `inference_engine_t` object, which will eliminate unnecessary subsequent computation inside the most performance-critical part Inference-Engine.  Changing the principal data structure in Inference-Engine will have pervasive impact.  The new unit tests will provide diagnostics that precisely and comprehensively identify the parts of Inference-Engine that must edited in order to accommodate the proposed change.