### PR TITLE
Enforce invariant `inference_engine_t` self-consistency

### DIFF
--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -37,8 +37,8 @@ module inference_engine_m
     procedure :: read_network
     procedure :: to_json
     procedure :: write_network
-    procedure :: infer_from_array_of_inputs
-    procedure :: infer_from_inputs_object
+    procedure, private :: infer_from_array_of_inputs
+    procedure, private :: infer_from_inputs_object
     generic :: infer => infer_from_array_of_inputs, infer_from_inputs_object
     procedure :: num_inputs
     procedure :: num_outputs

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -46,7 +46,7 @@ module inference_engine_m
     procedure :: num_hidden_layers
     procedure :: norm
     procedure :: conformable_with
-    procedure :: subtract
+    procedure, private :: subtract
     generic :: operator(-) => subtract
   end type
 

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -52,7 +52,7 @@ module inference_engine_m
 
   interface inference_engine_t
 
-    pure module function construct &
+    pure module function construct_from_components &
       (input_weights, hidden_weights, output_weights, biases, output_biases, inference_strategy, activation_strategy) &
       result(inference_engine)
       implicit none
@@ -63,7 +63,7 @@ module inference_engine_m
       type(inference_engine_t) inference_engine
     end function
 
-    impure elemental module function from_json(file_, activation_strategy, inference_strategy) result(inference_engine)
+    impure elemental module function construct_from_json(file_, activation_strategy, inference_strategy) result(inference_engine)
       implicit none
       type(file_t), intent(in) :: file_
       class(activation_strategy_t), intent(in), optional :: activation_strategy

--- a/src/inference_engine_s.f90
+++ b/src/inference_engine_s.f90
@@ -566,7 +566,6 @@ contains
     
     lines = file_%lines()
 
-
     call assert(adjustl(lines(1)%string())=="{", "from_json: expecting '{' for to start outermost object", lines(1)%string())
     call assert(adjustl(lines(2)%string())=='"hidden_layers": [', 'from_json: expecting "hidden_layers": [', lines(2)%string())
 
@@ -602,7 +601,6 @@ contains
       inference_engine%output_weights_ = reshape(output_weights, [1, size(output_weights)])
       inference_engine%output_biases_ = [output_neuron%bias()]
     end associate
-
 
     if (present(activation_strategy)) then
       inference_engine%activation_strategy_  = activation_strategy

--- a/src/inference_engine_s.f90
+++ b/src/inference_engine_s.f90
@@ -30,6 +30,9 @@ contains
     else
       inference_engine%inference_strategy_ = matmul_t()
     end if
+
+    call assert_consistent(inference_engine)
+
   end procedure
 
   module procedure construct_from_json

--- a/test/inference_engine_test_m.f90
+++ b/test/inference_engine_test_m.f90
@@ -137,10 +137,10 @@ contains
       type(outputs_t) true_true, true_false, false_true, false_false
       real(rkind), parameter :: tolerance = 1.E-08_rkind, false = 0._rkind, true = 1._rkind
 
-      true_true = inference_engine%infer_from_inputs_object(inputs=inputs_t([true,true]))
-      true_false = inference_engine%infer_from_inputs_object(inputs=inputs_t([true,false]))
-      false_true = inference_engine%infer_from_inputs_object(inputs=inputs_t([false,true]))
-      false_false = inference_engine%infer_from_inputs_object(inputs=inputs_t([false,false]))
+      true_true = inference_engine%infer(inputs=inputs_t([true,true]))
+      true_false = inference_engine%infer(inputs=inputs_t([true,false]))
+      false_true = inference_engine%infer(inputs=inputs_t([false,true]))
+      false_false = inference_engine%infer(inputs=inputs_t([false,false]))
 
       test_passes = [ &
         abs(true_true%outputs_ - false) < tolerance .and. abs(true_false%outputs_ - true) < tolerance .and. &


### PR DESCRIPTION
This PR enforces inference_engine_t internal self-consistency pre- and/or postconditions in every `inference_engine_t` type-bound procedure by calling the type-bound `assert_consistent()` subroutine.  Once this PR is merged, it should not be possible for any procedure to receive an `inference_engine_t` dummy argument that is internally inconsistent or to produce an `inference_engine_t` result that is internally inconsistent.