### PR TITLE
Transpose weights in the constructors

### DIFF
--- a/src/concurrent_dot_products_m.f90
+++ b/src/concurrent_dot_products_m.f90
@@ -22,12 +22,12 @@ module concurrent_dot_products_m
       input, input_weights, hidden_weights, biases, output_biases, output_weights, activation_strategy &
     ) result(output)
       implicit none
-      real(rkind), intent(in)  :: input(:)
-      real(rkind), intent(in), allocatable :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
-      real(rkind), intent(in), allocatable :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
-      real(rkind), intent(in), allocatable :: biases(:,:)           !! neuronal offsets for each hidden layer
-      real(rkind), intent(in), allocatable :: output_biases(:)      !! neuronal offsets applied to outputs
-      real(rkind), intent(in), allocatable :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
+      real(rkind), intent(in) :: input(:)
+      real(rkind), intent(in) :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
+      real(rkind), intent(in) :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
+      real(rkind), intent(in) :: biases(:,:)           !! neuronal offsets for each hidden layer
+      real(rkind), intent(in) :: output_biases(:)      !! neuronal offsets applied to outputs
+      real(rkind), intent(in) :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
       class(activation_strategy_t), intent(in) :: activation_strategy
       real(rkind), allocatable :: output(:)
     end function

--- a/src/concurrent_dot_products_s.f90
+++ b/src/concurrent_dot_products_s.f90
@@ -14,10 +14,10 @@ contains
     integer, parameter :: input_layer = 1
     real, allocatable :: neuron(:,:)
 
-    associate(neurons_per_layer => size(input_weights,2), num_layers => size(biases,2))
+    associate(neurons_per_layer => size(input_weights,1), num_layers => size(biases,2))
       allocate(neuron(neurons_per_layer, num_layers))
       do concurrent(n = 1:neurons_per_layer)
-        neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(:,n), input(:)) + biases(n,input_layer))
+        neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(n,:), input(:)) + biases(n,input_layer))
       end do
       do layer = 2, num_layers
         do concurrent(n = 1:neurons_per_layer)

--- a/src/concurrent_dot_products_s.f90
+++ b/src/concurrent_dot_products_s.f90
@@ -12,9 +12,10 @@ contains
     
     integer n, layer, m
     integer, parameter :: input_layer = 1
-    real, allocatable :: neuron(:,:)
+    real(rkind), allocatable :: neuron(:,:)
 
     associate(neurons_per_layer => size(input_weights,1), num_layers => size(biases,2))
+
       allocate(neuron(neurons_per_layer, num_layers))
       do concurrent(n = 1:neurons_per_layer)
         neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(n,:), input(:)) + biases(n,input_layer))
@@ -22,7 +23,7 @@ contains
       do layer = 2, num_layers
         do concurrent(n = 1:neurons_per_layer)
           neuron(n,layer) = &
-            activation_strategy%activation(dot_product(hidden_weights(:,n,layer-1), neuron(:,layer-1)) + biases(n,layer))
+            activation_strategy%activation(dot_product(hidden_weights(n,:,layer-1), neuron(:,layer-1)) + biases(n,layer))
         end do
       end do
 

--- a/src/concurrent_dot_products_with_skip_m.f90
+++ b/src/concurrent_dot_products_with_skip_m.f90
@@ -23,11 +23,11 @@ module concurrent_dot_products_with_skip_m
     ) result(output)
       implicit none
       real(rkind), intent(in)  :: input(:)
-      real(rkind), intent(in), allocatable :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
-      real(rkind), intent(in), allocatable :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
-      real(rkind), intent(in), allocatable :: biases(:,:)           !! neuronal offsets for each hidden layer
-      real(rkind), intent(in), allocatable :: output_biases(:)      !! neuronal offsets applied to outputs
-      real(rkind), intent(in), allocatable :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
+      real(rkind), intent(in) :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
+      real(rkind), intent(in) :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
+      real(rkind), intent(in) :: biases(:,:)           !! neuronal offsets for each hidden layer
+      real(rkind), intent(in) :: output_biases(:)      !! neuronal offsets applied to outputs
+      real(rkind), intent(in) :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
       class(activation_strategy_t), intent(in) :: activation_strategy
       real(rkind), allocatable :: output(:)
     end function

--- a/src/concurrent_dot_products_with_skip_s.f90
+++ b/src/concurrent_dot_products_with_skip_s.f90
@@ -14,10 +14,10 @@ contains
     integer, parameter :: input_layer = 1
     real, allocatable :: neuron(:,:)
 
-    associate(neurons_per_layer => size(input_weights,2), num_layers => size(biases,2))
+    associate(neurons_per_layer => size(input_weights,1), num_layers => size(biases,2))
       allocate(neuron(neurons_per_layer, num_layers))
       do concurrent(n = 1:neurons_per_layer)
-        neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(:,n), input(:)) + biases(n,input_layer))
+        neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(n,:), input(:)) + biases(n,input_layer))
       end do
       do layer = 2, num_layers
         do concurrent(n = 1:neurons_per_layer)

--- a/src/concurrent_dot_products_with_skip_s.f90
+++ b/src/concurrent_dot_products_with_skip_s.f90
@@ -12,9 +12,10 @@ contains
     
     integer n, layer, m
     integer, parameter :: input_layer = 1
-    real, allocatable :: neuron(:,:)
+    real(rkind), allocatable :: neuron(:,:)
 
     associate(neurons_per_layer => size(input_weights,1), num_layers => size(biases,2))
+
       allocate(neuron(neurons_per_layer, num_layers))
       do concurrent(n = 1:neurons_per_layer)
         neuron(n,input_layer) = activation_strategy%activation(dot_product(input_weights(n,:), input(:)) + biases(n,input_layer))
@@ -22,7 +23,7 @@ contains
       do layer = 2, num_layers
         do concurrent(n = 1:neurons_per_layer)
           neuron(n,layer) = neuron(n,layer-1) + &
-            activation_strategy%activation(dot_product(hidden_weights(:,n,layer-1), neuron(:,layer-1)) + biases(n,layer))
+            activation_strategy%activation(dot_product(hidden_weights(n,:,layer-1), neuron(:,layer-1)) + biases(n,layer))
         end do
       end do
 

--- a/src/inference_strategy_m.f90
+++ b/src/inference_strategy_m.f90
@@ -21,11 +21,11 @@ module inference_strategy_m
       import activation_strategy_t, rkind
       implicit none
       real(rkind), intent(in)  :: input(:)
-      real(rkind), intent(in), allocatable :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
-      real(rkind), intent(in), allocatable :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
-      real(rkind), intent(in), allocatable :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
-      real(rkind), intent(in), allocatable :: output_biases(:)      !! neuronal offsets applied to outputs
-      real(rkind), intent(in), allocatable :: biases(:,:)           !! neuronal offsets for each hidden layer
+      real(rkind), intent(in) :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
+      real(rkind), intent(in) :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
+      real(rkind), intent(in) :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
+      real(rkind), intent(in) :: output_biases(:)      !! neuronal offsets applied to outputs
+      real(rkind), intent(in) :: biases(:,:)           !! neuronal offsets for each hidden layer
       class(activation_strategy_t), intent(in) :: activation_strategy
       real(rkind), allocatable :: output(:)
     end function

--- a/src/matmul_m.f90
+++ b/src/matmul_m.f90
@@ -22,12 +22,12 @@ module matmul_m
       input, input_weights, hidden_weights, biases, output_biases, output_weights, activation_strategy &
     ) result(output)
       implicit none
-      real(rkind), intent(in)  :: input(:)
-      real(rkind), intent(in), allocatable :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
-      real(rkind), intent(in), allocatable :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
-      real(rkind), intent(in), allocatable :: biases(:,:)           !! neuronal offsets for each hidden layer
-      real(rkind), intent(in), allocatable :: output_biases(:)      !! neuronal offsets applied to outputs
-      real(rkind), intent(in), allocatable :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
+      real(rkind), intent(in) :: input(:)
+      real(rkind), intent(in) :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
+      real(rkind), intent(in) :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
+      real(rkind), intent(in) :: biases(:,:)           !! neuronal offsets for each hidden layer
+      real(rkind), intent(in) :: output_biases(:)      !! neuronal offsets applied to outputs
+      real(rkind), intent(in) :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
       class(activation_strategy_t), intent(in) :: activation_strategy
       real(rkind), allocatable :: output(:)
     end function

--- a/src/matmul_s.f90
+++ b/src/matmul_s.f90
@@ -8,8 +8,9 @@ contains
   module procedure infer
     
     real(rkind), allocatable :: neuron(:,:)
- 
+
     associate(num_layers => size(biases,2))
+
       associate(neurons_per_layer => size(input_weights,1))
         allocate(neuron(neurons_per_layer, num_layers))
       end associate
@@ -22,7 +23,7 @@ contains
         integer layer
         do layer = 2, num_layers
           neuron(:,layer) = &
-            activation_strategy%activation(matmul(transpose(hidden_weights(:,:,layer-1)), neuron(:,layer-1)) + biases(:,layer))
+            activation_strategy%activation(matmul(hidden_weights(:,:,layer-1), neuron(:,layer-1)) + biases(:,layer))
         end do
       end block
       output = activation_strategy%activation(matmul(output_weights(:,:), neuron(:,num_layers)) + output_biases(:))

--- a/src/matmul_s.f90
+++ b/src/matmul_s.f90
@@ -8,15 +8,15 @@ contains
   module procedure infer
     
     real(rkind), allocatable :: neuron(:,:)
-
+ 
     associate(num_layers => size(biases,2))
-      associate(neurons_per_layer => size(input_weights,2))
+      associate(neurons_per_layer => size(input_weights,1))
         allocate(neuron(neurons_per_layer, num_layers))
       end associate
       block
         integer, parameter :: input_layer = 1
         neuron(:,input_layer) = &
-          activation_strategy%activation(matmul(transpose(input_weights(:,:)), input(:)) + biases(:,input_layer))
+          activation_strategy%activation(matmul(input_weights(:,:), input(:)) + biases(:,input_layer))
       end block
       block
         integer layer

--- a/src/matmul_with_skip_m.f90
+++ b/src/matmul_with_skip_m.f90
@@ -22,12 +22,12 @@ module matmul_with_skip_m
       input, input_weights, hidden_weights, biases, output_biases, output_weights, activation_strategy &
     ) result(output)
       implicit none
-      real(rkind), intent(in)  :: input(:)
-      real(rkind), intent(in), allocatable :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
-      real(rkind), intent(in), allocatable :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
-      real(rkind), intent(in), allocatable :: biases(:,:)           !! neuronal offsets for each hidden layer
-      real(rkind), intent(in), allocatable :: output_biases(:)      !! neuronal offsets applied to outputs
-      real(rkind), intent(in), allocatable :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
+      real(rkind), intent(in) :: input(:)
+      real(rkind), intent(in) :: input_weights(:,:)    !! weights applied to go from the inputs to first hidden layer
+      real(rkind), intent(in) :: hidden_weights(:,:,:) !! weights applied to go from one hidden layer to the next
+      real(rkind), intent(in) :: biases(:,:)           !! neuronal offsets for each hidden layer
+      real(rkind), intent(in) :: output_biases(:)      !! neuronal offsets applied to outputs
+      real(rkind), intent(in) :: output_weights(:,:)   !! weights applied to go from the final hidden layer to the outputs
       class(activation_strategy_t), intent(in) :: activation_strategy
       real(rkind), allocatable :: output(:)
     end function

--- a/src/matmul_with_skip_s.f90
+++ b/src/matmul_with_skip_s.f90
@@ -10,6 +10,7 @@ contains
     real(rkind), allocatable :: neuron(:,:)
 
     associate(num_layers => size(biases,2))
+
       associate(neurons_per_layer => size(input_weights,1))
         allocate(neuron(neurons_per_layer, num_layers))
       end associate
@@ -22,7 +23,7 @@ contains
         integer layer
         do layer = 2, num_layers
           neuron(:,layer) = neuron(:,layer-1) + &
-            activation_strategy%activation(matmul(transpose(hidden_weights(:,:,layer-1)), neuron(:,layer-1)) + biases(:,layer))
+            activation_strategy%activation(matmul(hidden_weights(:,:,layer-1), neuron(:,layer-1)) + biases(:,layer))
         end do
       end block
       output = activation_strategy%activation(matmul(output_weights(:,:), neuron(:,num_layers)) + output_biases(:))

--- a/src/matmul_with_skip_s.f90
+++ b/src/matmul_with_skip_s.f90
@@ -10,13 +10,13 @@ contains
     real(rkind), allocatable :: neuron(:,:)
 
     associate(num_layers => size(biases,2))
-      associate(neurons_per_layer => size(input_weights,2))
+      associate(neurons_per_layer => size(input_weights,1))
         allocate(neuron(neurons_per_layer, num_layers))
       end associate
       block
         integer, parameter :: input_layer = 1
         neuron(:,input_layer) = &
-          activation_strategy%activation(matmul(transpose(input_weights(:,:)), input(:)) + biases(:,input_layer))
+          activation_strategy%activation(matmul(input_weights(:,:), input(:)) + biases(:,input_layer))
       end block
       block
         integer layer
@@ -25,7 +25,7 @@ contains
             activation_strategy%activation(matmul(transpose(hidden_weights(:,:,layer-1)), neuron(:,layer-1)) + biases(:,layer))
         end do
       end block
-      output =  activation_strategy%activation(matmul(output_weights(:,:), neuron(:,num_layers)) + output_biases(:))
+      output = activation_strategy%activation(matmul(output_weights(:,:), neuron(:,num_layers)) + output_biases(:))
     end associate
 
   end procedure


### PR DESCRIPTION
This PR refactors the `inference_engine_t` user-defined constructor functions to store the `input_weights_` and `hidden_weights_` components in a form that is transposed relative to the corresponding constructor dummy arguments. Transposing the weights arrays inside the the constructors keeps the procedure interfaces the same but eliminates the need for transposition each time the `matmul` intrinsic is called during inference (once per layer), thus saving computation.