### PR TITLE
Feature: read metadata if present

### DIFF
--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -13,7 +13,6 @@ module inference_engine_m
   public :: inference_engine_t
   public :: inputs_t
   public :: outputs_t
-  public :: infer_from_inputs_object
 
   type inputs_t
     real(rkind), allocatable :: inputs_(:)
@@ -23,9 +22,15 @@ module inference_engine_m
     real(rkind), allocatable :: outputs_(:)
   end type
 
+  type metadata_t
+    character(len=:), allocatable :: modelName, modelAuthor, compilationDate
+    logical usingSkipConnections
+  end type
+
   type inference_engine_t
     !! Encapsulate the minimal information needed to performance inference
     private
+    type(metadata_t) metadata_
     real(rkind), allocatable :: input_weights_(:,:)    ! weights applied to go from the inputs to first hidden layer
     real(rkind), allocatable :: hidden_weights_(:,:,:) ! weights applied to go from one hidden layer to the next
     real(rkind), allocatable :: output_weights_(:,:)   ! weights applied to go from the final hidden layer to the outputs


### PR DESCRIPTION
This PR adds the capability to read a `metadata` JSON object if it is present before the `hidden_layers` array and formatted as follows:
```
    "metadata": {
        "modelName": "Network",
        "modelAuthor": "Joe Bloggs",
        "compilationDate": "2023-02-09 16:10:18.544724",
        "usingSkipConnections": false
    },
```
The corresponding information is used to construct a `metadata_t` object that is a new component in the `inference_engine_t` derive type.  If no `metadata` JSON object is found, then the `metadata_t` component is constructed with empty strings  and a `.false.`. The primary purpose of the new metadata object is to specify whether skip connections will be used between hidden layers.