### PR TITLE
fix(netcdf-interfaces): patch for fpm v >= 0.8

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -7,4 +7,4 @@ maintainer = "rouson@lbl.gov"
 [dependencies]
 assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.4.0"}
 sourcery = {git = "https://github.com/sourceryinstitute/sourcery", tag = "3.6.0"}
-netcdf-interfaces = {git = "https://github.com/LKedward/netcdf-interfaces.git"}
+netcdf-interfaces = {git = "https://github.com/rouson/netcdf-interfaces.git", branch = "implicit-interfaces"}


### PR DESCRIPTION
This commit switches to using a version of the netcdf-interfaces dependency that has been patched to allow the use of implicit external interfaces.