### PR TITLE
Group input/output pairs into mini-batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ Table of contents
 Overview
 --------
 
-Inference-Engine is a software library for researching ways to efficiently propagate inputs through deep, feed-forward neural networks exported from Python by the companion package [nexport].  Inference-Engine's implementation language, Fortran 2018, makes it suitable for integration into high-performance computing (HPC) applications.  The first HPC application of interest is the Intermediate Complexity Atmospheric Research ([ICAR]) model.  The novel features of Inference-Engine include
+Inference-Engine is a software library for researching concurrent, large-batch inference and training of deep, feed-forward neural networks.  Inference-Engine targets high-performance computing (HPC) applications with performance-critical inference and training needs.  The initial target application is _in situ_ training of a cloud microphysics model proxy for the Intermediate Complexity Atmospheric Research ([ICAR]) model.  Such a proxy must support concurrent inference at every grid point at every time step of an ICAR run.  As of this writing, the code on the main branch supports concurrent inference.  A draft pull request supports concurrent training.  For validation purposes, Inference-Engine can also import neural networks exported from Python by the companion package [nexport].
+
+Inference-Engine's implementation language, Fortran 2018, makes it suitable for integration into high-performance computing (HPC).
+The novel features of Inference-Engine include
 
 1. Exposing concurrency via 
-  - An `elemental` inference function
-  - An `elemental` activation strategy 
+  - An `elemental` and implicitly `pure` inference function: `infer`.
+  - An `elemental` and implicitly `pure` activation strategy pattern.
 2. Gathering network weights and biases into contiguous arrays
-3. Runtime selection of inference algorithm
+3. Runtime selection of inferences strategy and activation strategy. 
   
 Item 1 ensures that the `infer` procedure can be invoked inside Fortran's `do concurrent` construct, which some compilers can offload automatically to graphics processing units (GPUs).  We envision this being useful in applications that require large numbers of independent inferences.  Item 2 exploits the special case where the number of neurons is uniform across the network layers.  The use of contiguous arrays facilitates spatial locality in memory access patterns.  Item 3 offers the possibility of adaptive inference method selection based on runtime information.  The current methods include ones based on intrinsic functions, `dot_product` or `matmul`.  Future options will explore the use of OpenMP and OpenACC for vectorization, multithreading, and/or accelerator offloading.
 

--- a/example/train-xor-gate.f90
+++ b/example/train-xor-gate.f90
@@ -1,0 +1,110 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+program train_xor_gate
+  !! Define inference tests and procedures required for reporting results
+  use string_m, only : string_t
+  use trainable_engine_m, only : trainable_engine_t
+  use inputs_m, only : inputs_t
+  use outputs_m, only : outputs_t
+  use expected_outputs_m, only : expected_outputs_t
+  use matmul_m, only : matmul_t
+  use kind_parameters_m, only : rkind
+  use sigmoid_m, only : sigmoid_t
+  use input_output_pair_m, only : input_output_pair_t 
+  use mini_batch_m, only : mini_batch_t
+  use file_m, only : file_t
+  use command_line_m, only : command_line_t
+  implicit none
+
+  real(rkind), parameter :: tolerance = 1.E-02_rkind, false = 0._rkind, true = 1._rkind
+  type(outputs_t), dimension(4) :: actual_output
+  type(expected_outputs_t), dimension(4) :: expected_outputs 
+  type(trainable_engine_t) trainable_engine
+  type(command_line_t) command_line
+  type(string_t) base_name
+  type(mini_batch_t), allocatable :: mini_batches(:)
+  character(len=5), parameter :: table_entry(*) = ["TT->F", "FT->T", "TF->T", "FF->F", "xor  "]
+  integer i, j, m
+
+  base_name = string_t(command_line%flag_value("--base-name"))
+ 
+  if (len(base_name%string())==0) then
+    error stop new_line('a') // new_line('a') // &
+      'Usage: ./build/run-fpm.sh run --example train-xor-gate -- --base-name "<base-file-name>"'
+  end if
+
+  block
+    expected_outputs = [ &
+      expected_outputs_t([false]), expected_outputs_t([true]), expected_outputs_t([true]), expected_outputs_t([false]) &
+    ] 
+    associate( &
+      inputs => [ &
+        inputs_t([true,true]), inputs_t([false,true]), inputs_t([true,false]), inputs_t([false,false]) &
+      ] &
+    )
+     loop_over_truth_table_entries: &
+     do j =1, size(inputs)
+       trainable_engine = trainable_single_layer_perceptron()
+       call trainable_engine%train([(mini_batch_t(input_output_pair_t([inputs(j)], [expected_outputs(j)])), i=1,3000)], matmul_t())
+       call output(trainable_engine, string_t(base_name%string()//"-"//trim(table_entry(j))//".json"))
+       actual_output(j) = trainable_engine%infer(inputs(j), matmul_t())
+     end do loop_over_truth_table_entries
+    end associate
+    
+
+    !if (.not. all([(abs(actual_output(j)%outputs() - expected_outputs(j)%outputs()) < tolerance, j=1, size(inputs))])) &
+    !   error stop "one or more models failed to converge"
+  end block
+
+  block
+    type(inputs_t), allocatable :: inputs(:)
+
+    inputs = [ &
+      inputs_t([true,true]), inputs_t([false,true]), inputs_t([true,false]), inputs_t([false,false]) &
+    ]
+    expected_outputs = [ &
+      expected_outputs_t([false]), expected_outputs_t([true]), expected_outputs_t([true]), expected_outputs_t([false]) &
+    ]
+    mini_batches = [(mini_batch_t( input_output_pair_t( inputs, expected_outputs ) ), m=1,2000)]
+    trainable_engine = trainable_single_layer_perceptron()
+    call trainable_engine%train(mini_batches, matmul_t())
+    call output(trainable_engine, string_t(base_name%string()//"-"//trim(table_entry(5))//".json"))
+    call output(trainable_engine, string_t(base_name%string() // ".json"))
+    actual_output = trainable_engine%infer(inputs, matmul_t())
+    ! if (.not. all([(abs(actual_output(i)%outputs() - expected_outputs(i)%outputs()) < tolerance, i=1, size(inputs))])) &
+    !   error stop "the model failed to converge"
+  end block
+
+contains
+
+  subroutine output(engine, file_name)
+    type(trainable_engine_t), intent(in) :: engine
+    type(string_t), intent(in) :: file_name
+    type(file_t) json_file
+ 
+    json_file = trainable_engine%to_json()
+    print *, "Writing an inference_engine_t object to the file '"//file_name%string()//"' in JSON format."
+    call json_file%write_lines(file_name)
+  end subroutine
+
+  function trainable_single_layer_perceptron() result(trainable_engine)
+    type(trainable_engine_t) trainable_engine
+    integer, parameter :: n_in = 2 ! number of inputs
+    integer, parameter :: n_out = 1 ! number of outputs
+    integer, parameter :: neurons = 3 ! number of neurons per layer
+    integer, parameter :: n_hidden = 1 ! number of hidden layers 
+   
+    trainable_engine = trainable_engine_t( &
+      metadata = [ &
+       string_t("Trainable XOR"), string_t("Damian Rouson"), string_t("2023-05-09"), string_t("sigmoid"), string_t("false") &
+      ], &
+      input_weights = real(reshape([1,0,1,1,0,1], [n_in, neurons]), rkind), &
+      hidden_weights = reshape([real(rkind)::], [neurons,neurons,n_hidden-1]), &
+      output_weights = real(reshape([1,-2,1], [n_out, neurons]), rkind), &
+      biases = reshape([real(rkind):: 0.,-1.99,0.], [neurons, n_hidden]), &
+      output_biases = [real(rkind):: 0.], &
+      differentiable_activation_strategy = sigmoid_t() &
+    )
+  end function
+
+end program train_xor_gate

--- a/setup.sh
+++ b/setup.sh
@@ -65,9 +65,9 @@ HDF5_LIB_PATH="`brew --prefix hdf5`/lib"
 NETCDFF_LIB_PATH="`brew --prefix netcdf-fortran`/lib"
 
 FPM_LD_FLAG=" -L$NETCDF_LIB_PATH -L$HDF5_LIB_PATH -L$NETCDFF_LIB_PATH"
-FPM_FLAG="-fallow-argument-mismatch -ffree-line-length-none -L$NETCDF_LIB_PATH -L$HDF5_LIB_PATH"
-FPM_FC=${FC:-"gfortran-12"}
-FPM_CC=${CC:-"gcc-12"}
+FPM_FLAG="-O3 -fallow-argument-mismatch -ffree-line-length-none -L$NETCDF_LIB_PATH -L$HDF5_LIB_PATH"
+FPM_FC=${FC:-"gfortran-13"}
+FPM_CC=${CC:-"gcc-13"}
 
 mkdir -p build
 
@@ -106,7 +106,7 @@ export PKG_CONFIG_PATH
 cp scripts/run-fpm.sh-header build/run-fpm.sh
 RUN_FPM_SH="`realpath ./build/run-fpm.sh`"
 echo "`which fpm` \$fpm_arguments \\" >>  $RUN_FPM_SH
-echo "--profile debug \\" >> $RUN_FPM_SH
+echo "--profile release \\" >> $RUN_FPM_SH
 echo "--c-compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_CC`\" \\" >> $RUN_FPM_SH
 echo "--compiler \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FC`\" \\" >> $RUN_FPM_SH
 echo "--flag \"`pkg-config inference-engine --variable=INFERENCE_ENGINE_FPM_FLAG`\" \\"  >> $RUN_FPM_SH

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -10,6 +10,7 @@ module inference_engine_m_
   use inputs_m, only : inputs_t
   use outputs_m, only : outputs_t
   use differentiable_activation_strategy_m, only :differentiable_activation_strategy_t
+  use network_increment_m, only : network_increment_t
   implicit none
 
   private
@@ -171,12 +172,10 @@ module inference_engine_m_
       real(rkind), allocatable :: w(:,:)
     end function
 
-    pure module subroutine increment(self, delta_w_in, delta_w_hidden, delta_w_out, delta_b_hidden, delta_b_out)
+    pure module subroutine increment(self, network_increment)
       implicit none
       class(inference_engine_t), intent(inout) :: self
-      real(rkind), intent(in), dimension(:,:,:) :: delta_w_hidden
-      real(rkind), intent(in), dimension(:,:) :: delta_w_in, delta_w_out, delta_b_hidden
-      real(rkind), intent(in), dimension(:) :: delta_b_out
+      type(network_increment_t), intent(in) :: network_increment
     end subroutine
 
   end interface

--- a/src/inference_engine/inference_engine_s.f90
+++ b/src/inference_engine/inference_engine_s.f90
@@ -448,11 +448,11 @@ contains
   end procedure
 
   module procedure increment
-    self%input_weights_ = self%input_weights_ + delta_w_in
-    self%hidden_weights_ = self%hidden_weights_ + delta_w_hidden
-    self%output_weights_ = self%output_weights_ + delta_w_out
-    self%biases_ = self%biases_ + delta_b_hidden
-    self%output_biases_ = self%output_biases_ + delta_b_out
+    self%input_weights_ = self%input_weights_ + network_increment%delta_w_in()
+    self%hidden_weights_ = self%hidden_weights_ + network_increment%delta_w_hidden()
+    self%output_weights_ = self%output_weights_ + network_increment%delta_w_out()
+    self%biases_ = self%biases_ + network_increment%delta_b_hidden()
+    self%output_biases_ = self%output_biases_ + network_increment%delta_b_out()
   end procedure
 
 end submodule inference_engine_s

--- a/src/inference_engine/mini_batch_m.f90
+++ b/src/inference_engine/mini_batch_m.f90
@@ -1,6 +1,5 @@
 module mini_batch_m
   use input_output_pair_m, only : input_output_pair_t
-  use network_increment_m, only : network_increment_t
   use kind_parameters_m, only : rkind
   implicit none
 
@@ -10,17 +9,15 @@ module mini_batch_m
   type mini_batch_t
     private
     type(input_output_pair_t), allocatable :: input_output_pairs_(:)
-    type(network_increment_t), allocatable :: network_increments_(:)
   contains
-    procedure :: average_increment
+    procedure :: input_output_pairs
   end type
 
   interface mini_batch_t
 
-    pure module function construct(input_output_pairs, network_increments) result(mini_batch)
+    pure module function construct(input_output_pairs) result(mini_batch)
       implicit none
       type(input_output_pair_t), intent(in) :: input_output_pairs(:)
-      type(network_increment_t), intent(in) :: network_increments(:)
       type(mini_batch_t) mini_batch
     end function
 
@@ -28,10 +25,10 @@ module mini_batch_m
 
   interface
 
-    pure module function average_increment(self) result(average)
+    pure module function input_output_pairs(self) result(my_input_output_pairs)
       implicit none
       class(mini_batch_t), intent(in) :: self
-      type(network_increment_t) average
+      type(input_output_pair_t), allocatable :: my_input_output_pairs(:)
     end function
 
   end interface

--- a/src/inference_engine/mini_batch_m.f90
+++ b/src/inference_engine/mini_batch_m.f90
@@ -1,0 +1,39 @@
+module mini_batch_m
+  use input_output_pair_m, only : input_output_pair_t
+  use network_increment_m, only : network_increment_t
+  use kind_parameters_m, only : rkind
+  implicit none
+
+  private
+  public :: mini_batch_t
+
+  type mini_batch_t
+    private
+    type(input_output_pair_t), allocatable :: input_output_pairs_(:)
+    type(network_increment_t), allocatable :: network_increments_(:)
+  contains
+    procedure :: average_increment
+  end type
+
+  interface mini_batch_t
+
+    pure module function construct(input_output_pairs, network_increments) result(mini_batch)
+      implicit none
+      type(input_output_pair_t), intent(in) :: input_output_pairs(:)
+      type(network_increment_t), intent(in) :: network_increments(:)
+      type(mini_batch_t) mini_batch
+    end function
+
+  end interface
+
+  interface
+
+    pure module function average_increment(self) result(average)
+      implicit none
+      class(mini_batch_t), intent(in) :: self
+      type(network_increment_t) average
+    end function
+
+  end interface
+
+end module mini_batch_m

--- a/src/inference_engine/mini_batch_s.f90
+++ b/src/inference_engine/mini_batch_s.f90
@@ -1,0 +1,32 @@
+submodule(mini_batch_m) mini_batch_s
+  use assert_m, only : assert
+  implicit none
+
+contains
+
+    module procedure construct
+      mini_batch%input_output_pairs_ = input_output_pairs
+      mini_batch%network_increments_ = network_increments
+    end procedure
+
+    module procedure average_increment
+
+      type(network_increment_t) total
+      integer i
+
+      associate(num_increments => size(self%network_increments_))
+
+        call assert(num_increments > 0, "mini_batch_s average_increment: num_increments > 0") 
+
+        total = self%network_increments_(1)
+
+        do i = 2, num_increments ! In Fortran 2023, this could be a concurrent reduction
+          total = total + self%network_increments_(i)
+        end do
+
+        average = total/num_increments
+
+      end associate
+    end procedure
+
+end submodule mini_batch_s

--- a/src/inference_engine/mini_batch_s.f90
+++ b/src/inference_engine/mini_batch_s.f90
@@ -1,32 +1,14 @@
 submodule(mini_batch_m) mini_batch_s
-  use assert_m, only : assert
   implicit none
 
 contains
 
     module procedure construct
       mini_batch%input_output_pairs_ = input_output_pairs
-      mini_batch%network_increments_ = network_increments
     end procedure
 
-    module procedure average_increment
-
-      type(network_increment_t) total
-      integer i
-
-      associate(num_increments => size(self%network_increments_))
-
-        call assert(num_increments > 0, "mini_batch_s average_increment: num_increments > 0") 
-
-        total = self%network_increments_(1)
-
-        do i = 2, num_increments ! In Fortran 2023, this could be a concurrent reduction
-          total = total + self%network_increments_(i)
-        end do
-
-        average = total/num_increments
-
-      end associate
+    module procedure input_output_pairs
+      my_input_output_pairs = self%input_output_pairs_
     end procedure
 
 end submodule mini_batch_s

--- a/src/inference_engine/network_increment_m.f90
+++ b/src/inference_engine/network_increment_m.f90
@@ -1,0 +1,54 @@
+module network_increment_m
+  use kind_parameters_m, only : rkind
+  implicit none
+
+  private
+  public :: network_increment_t
+
+  type network_increment_t
+    private
+    real(rkind), allocatable :: delta_w_in_(:,:)
+    real(rkind), allocatable :: delta_w_hidden_(:,:,:)
+    real(rkind), allocatable :: delta_w_out_(:,:)
+    real(rkind), allocatable :: delta_b_(:,:)
+    real(rkind), allocatable :: delta_b_out_(:)
+  contains
+    procedure, private :: add
+    generic :: operator(+) => add
+    procedure, private :: divide
+    generic :: operator(/) => divide
+  end type
+
+  interface network_increment_t
+
+    pure module function construct(delta_w_in, delta_w_hidden, delta_w_out, delta_b, delta_b_out) result(network_increment)
+      implicit none
+      real(rkind), allocatable, intent(in) :: delta_w_in(:,:)
+      real(rkind), allocatable, intent(in) :: delta_w_hidden(:,:,:)
+      real(rkind), allocatable, intent(in) :: delta_w_out(:,:)
+      real(rkind), allocatable, intent(in) :: delta_b(:,:)
+      real(rkind), allocatable, intent(in) :: delta_b_out(:)
+      type(network_increment_t) network_increment
+    end function
+
+  end interface
+
+  interface
+
+    pure module function add(lhs, rhs) result(total)
+      implicit none
+      class(network_increment_t), intent(in) :: lhs
+      type(network_increment_t), intent(in) :: rhs
+      type(network_increment_t) total
+    end function
+
+    pure module function divide(numerator, denominator) result(ratio)
+      implicit none
+      class(network_increment_t), intent(in) :: numerator
+      integer, intent(in) :: denominator
+      type(network_increment_t) ratio
+    end function
+
+  end interface
+
+end module network_increment_m

--- a/src/inference_engine/network_increment_m.f90
+++ b/src/inference_engine/network_increment_m.f90
@@ -4,6 +4,7 @@ module network_increment_m
 
   private
   public :: network_increment_t
+  public :: operator(.average.)
 
   type network_increment_t
     private
@@ -30,6 +31,16 @@ module network_increment_m
       real(rkind), allocatable, intent(in) :: delta_b_out(:)
       type(network_increment_t) network_increment
     end function
+
+  end interface
+ 
+  interface operator(.average.)
+
+     pure module function average(rhs) result(average_increment)
+       implicit none
+       type(network_increment_t) rhs(:)
+       type(network_increment_t) average_increment
+     end function
 
   end interface
 

--- a/src/inference_engine/network_increment_m.f90
+++ b/src/inference_engine/network_increment_m.f90
@@ -11,24 +11,29 @@ module network_increment_m
     real(rkind), allocatable :: delta_w_in_(:,:)
     real(rkind), allocatable :: delta_w_hidden_(:,:,:)
     real(rkind), allocatable :: delta_w_out_(:,:)
-    real(rkind), allocatable :: delta_b_(:,:)
+    real(rkind), allocatable :: delta_b_hidden_(:,:)
     real(rkind), allocatable :: delta_b_out_(:)
   contains
     procedure, private :: add
     generic :: operator(+) => add
     procedure, private :: divide
     generic :: operator(/) => divide
+    procedure :: delta_w_in
+    procedure :: delta_w_hidden
+    procedure :: delta_w_out
+    procedure :: delta_b_hidden
+    procedure :: delta_b_out
   end type
 
   interface network_increment_t
 
-    pure module function construct(delta_w_in, delta_w_hidden, delta_w_out, delta_b, delta_b_out) result(network_increment)
+    pure module function construct(delta_w_in, delta_w_hidden, delta_w_out, delta_b_hidden, delta_b_out) result(network_increment)
       implicit none
-      real(rkind), allocatable, intent(in) :: delta_w_in(:,:)
-      real(rkind), allocatable, intent(in) :: delta_w_hidden(:,:,:)
-      real(rkind), allocatable, intent(in) :: delta_w_out(:,:)
-      real(rkind), allocatable, intent(in) :: delta_b(:,:)
-      real(rkind), allocatable, intent(in) :: delta_b_out(:)
+      real(rkind), intent(in) :: delta_w_in(:,:)
+      real(rkind), intent(in) :: delta_w_hidden(:,:,:)
+      real(rkind), intent(in) :: delta_w_out(:,:)
+      real(rkind), intent(in) :: delta_b_hidden(:,:)
+      real(rkind), intent(in) :: delta_b_out(:)
       type(network_increment_t) network_increment
     end function
 
@@ -38,7 +43,7 @@ module network_increment_m
 
      pure module function average(rhs) result(average_increment)
        implicit none
-       type(network_increment_t) rhs(:)
+       type(network_increment_t), intent(in) :: rhs(:)
        type(network_increment_t) average_increment
      end function
 
@@ -58,6 +63,36 @@ module network_increment_m
       class(network_increment_t), intent(in) :: numerator
       integer, intent(in) :: denominator
       type(network_increment_t) ratio
+    end function
+    
+    pure module function delta_w_in(self) result(my_delta_w_in)
+      implicit none
+      class(network_increment_t), intent(in) :: self
+      real(rkind), allocatable :: my_delta_w_in(:,:)
+    end function
+
+    pure module function delta_w_hidden(self) result(my_delta_w_hidden)
+      implicit none
+      class(network_increment_t), intent(in) :: self
+      real(rkind), allocatable :: my_delta_w_hidden(:,:,:)
+    end function
+
+    pure module function delta_w_out(self) result(my_delta_w_out)
+      implicit none
+      class(network_increment_t), intent(in) :: self
+      real(rkind), allocatable :: my_delta_w_out(:,:)
+    end function
+
+    pure module function delta_b_hidden(self) result(my_delta_b_hidden)
+      implicit none
+      class(network_increment_t), intent(in) :: self
+      real(rkind), allocatable :: my_delta_b_hidden(:,:)
+    end function
+
+    pure module function delta_b_out(self) result(my_delta_b_out)
+      implicit none
+      class(network_increment_t), intent(in) :: self
+      real(rkind), allocatable :: my_delta_b_out(:)
     end function
 
   end interface

--- a/src/inference_engine/network_increment_s.f90
+++ b/src/inference_engine/network_increment_s.f90
@@ -1,30 +1,30 @@
 submodule(network_increment_m) network_increment_s
-  use kind_parameters_m, only : rkind
+  use assert_m, only : assert
   implicit none
 
 contains
 
   module procedure construct
-    network_increment%delta_w_in_ =  delta_w_in
+    network_increment%delta_w_in_     =  delta_w_in
     network_increment%delta_w_hidden_ =  delta_w_hidden
-    network_increment%delta_w_out_ = delta_w_out
-    network_increment%delta_b_ =  delta_b
-    network_increment%delta_b_out_ =  delta_b_out 
+    network_increment%delta_w_out_    = delta_w_out
+    network_increment%delta_b_hidden_ =  delta_b_hidden
+    network_increment%delta_b_out_    =  delta_b_out 
   end procedure
 
   module procedure add
     total%delta_w_in_     = lhs%delta_w_in_     + rhs%delta_w_in_
     total%delta_w_hidden_ = lhs%delta_w_hidden_ + rhs%delta_w_hidden_
     total%delta_w_out_    = lhs%delta_w_out_    + rhs%delta_w_out_
-    total%delta_b_        = lhs%delta_b_       + rhs%delta_b_
-    total%delta_b_out_    = lhs%delta_b_out_   + rhs%delta_b_out_
+    total%delta_b_hidden_ = lhs%delta_b_hidden_ + rhs%delta_b_hidden_
+    total%delta_b_out_    = lhs%delta_b_out_    + rhs%delta_b_out_
   end procedure
 
   module procedure divide
     ratio%delta_w_in_     = numerator%delta_w_in_     / denominator
     ratio%delta_w_hidden_ = numerator%delta_w_hidden_ / denominator
     ratio%delta_w_out_    = numerator%delta_w_out_    / denominator
-    ratio%delta_b_        = numerator%delta_b_        / denominator
+    ratio%delta_b_hidden_ = numerator%delta_b_hidden_ / denominator
     ratio%delta_b_out_    = numerator%delta_b_out_    / denominator
   end procedure
 
@@ -43,10 +43,30 @@ contains
         total = total + rhs(i)
       end do
 
-      average_increment = rhs/num_increments
+      average_increment = total%divide(num_increments)
 
     end associate
 
+  end procedure
+
+  module procedure delta_w_in
+    my_delta_w_in = self%delta_w_in_
+  end procedure 
+
+  module procedure delta_w_hidden
+    my_delta_w_hidden = self%delta_w_hidden_
+  end procedure
+
+  module procedure delta_w_out
+    my_delta_w_out = self%delta_w_out_
+  end procedure
+
+  module procedure delta_b_hidden
+    my_delta_b_hidden = self%delta_b_hidden_
+  end procedure
+    
+  module procedure delta_b_out
+    my_delta_b_out = self%delta_b_out_
   end procedure
 
 end submodule network_increment_s

--- a/src/inference_engine/network_increment_s.f90
+++ b/src/inference_engine/network_increment_s.f90
@@ -1,0 +1,31 @@
+submodule(network_increment_m) network_increment_s
+  use kind_parameters_m, only : rkind
+  implicit none
+
+contains
+
+  module procedure construct
+    network_increment%delta_w_in_ =  delta_w_in
+    network_increment%delta_w_hidden_ =  delta_w_hidden
+    network_increment%delta_w_out_ = delta_w_out
+    network_increment%delta_b_ =  delta_b
+    network_increment%delta_b_out_ =  delta_b_out 
+  end procedure
+
+  module procedure add
+    total%delta_w_in_     = lhs%delta_w_in_     + rhs%delta_w_in_
+    total%delta_w_hidden_ = lhs%delta_w_hidden_ + rhs%delta_w_hidden_
+    total%delta_w_out_    = lhs%delta_w_out_    + rhs%delta_w_out_
+    total%delta_b_        = lhs%delta_b_       + rhs%delta_b_
+    total%delta_b_out_    = lhs%delta_b_out_   + rhs%delta_b_out_
+  end procedure
+
+  module procedure divide
+    ratio%delta_w_in_     = numerator%delta_w_in_     / denominator
+    ratio%delta_w_hidden_ = numerator%delta_w_hidden_ / denominator
+    ratio%delta_w_out_    = numerator%delta_w_out_    / denominator
+    ratio%delta_b_        = numerator%delta_b_        / denominator
+    ratio%delta_b_out_    = numerator%delta_b_out_    / denominator
+  end procedure
+
+end submodule network_increment_s

--- a/src/inference_engine/network_increment_s.f90
+++ b/src/inference_engine/network_increment_s.f90
@@ -28,4 +28,25 @@ contains
     ratio%delta_b_out_    = numerator%delta_b_out_    / denominator
   end procedure
 
+  module procedure average
+
+    type(network_increment_t) total
+    integer i
+
+    associate(num_increments => size(rhs))
+
+      call assert(num_increments > 0, "mini_batch_s average_increment: num_increments > 0") 
+
+      total = rhs(1)
+
+      do i = 2, num_increments ! In Fortran 2023, this could be a concurrent reduction
+        total = total + rhs(i)
+      end do
+
+      average_increment = rhs/num_increments
+
+    end associate
+
+  end procedure
+
 end submodule network_increment_s

--- a/src/inference_engine/trainable_engine_m.f90
+++ b/src/inference_engine/trainable_engine_m.f90
@@ -9,7 +9,7 @@ module trainable_engine_m
   use kind_parameters_m, only : rkind
   use inputs_m, only : inputs_t
   use expected_outputs_m, only : expected_outputs_t
-  use input_output_pair_m, only : input_output_pair_t 
+  use mini_batch_m, only : mini_batch_t
   implicit none
 
   private
@@ -41,10 +41,10 @@ module trainable_engine_m
 
   interface
 
-    pure module subroutine train(self, input_output_pairs, inference_strategy)
+    pure module subroutine train(self, mini_batch, inference_strategy)
       implicit none
       class(trainable_engine_t), intent(inout) :: self
-      type(input_output_pair_t), intent(in) :: input_output_pairs(:)
+      type(mini_batch_t), intent(in) :: mini_batch
       class(inference_strategy_t), intent(in) :: inference_strategy
     end subroutine
 

--- a/src/inference_engine/trainable_engine_m.f90
+++ b/src/inference_engine/trainable_engine_m.f90
@@ -44,7 +44,7 @@ module trainable_engine_m
     pure module subroutine train(self, mini_batch, inference_strategy)
       implicit none
       class(trainable_engine_t), intent(inout) :: self
-      type(mini_batch_t), intent(in) :: mini_batch
+      type(mini_batch_t), intent(in) :: mini_batch(:)
       class(inference_strategy_t), intent(in) :: inference_strategy
     end subroutine
 

--- a/src/inference_engine/trainable_engine_s.f90
+++ b/src/inference_engine/trainable_engine_s.f90
@@ -2,75 +2,92 @@
 ! Terms of use are as specified in LICENSE.txt
 submodule(trainable_engine_m) trainable_engine_s
   use outputs_m, only : outputs_t
+  use network_increment_m, only : network_increment_t, operator(.average.)
   implicit none
 
 contains
 
   module procedure train
 
-    type(outputs_t) actual_outputs ! compiler issue: gfortran won't let this be `associate`
-    integer i, l
+    integer pair, l, batch
     real(rkind), allocatable  :: delta(:,:), delta_in(:), delta_w(:,:,:)
+    type(outputs_t), allocatable :: actual_outputs(:)
+    type(network_increment_t), allocatable :: network_increments(:)
 
     call self%assert_consistent
 
-    associate(input_output_pairs => mini_batch%input_output_pairs())
+    associate( &
+      num_hidden_layers => self%num_hidden_layers(), &
+      neurons_per_layer => self%neurons_per_layer() &
+    )
+      allocate(delta(neurons_per_layer, num_hidden_layers))
+      allocate(delta_w(neurons_per_layer, neurons_per_layer, num_hidden_layers-1))
 
-      associate( &
-        num_hidden_layers => self%num_hidden_layers(), &
-        neurons_per_layer => self%neurons_per_layer(), &
-        expected_outputs => input_output_pairs%expected_outputs(), &
-        inputs => input_output_pairs%inputs() &
-      )
-        allocate(delta(neurons_per_layer, num_hidden_layers))
-        allocate(delta_w(neurons_per_layer, neurons_per_layer, num_hidden_layers-1))
+      loop_over_mini_batches: &
+      do batch = 1, size(mini_batch)
 
-        do i = 1, size(inputs)
-
-          actual_outputs = self%infer(inputs(i), inference_strategy) 
-
+        associate(input_output_pairs => mini_batch(batch)%input_output_pairs())
           associate( &
-            a_L => actual_outputs%outputs(), &
-            y_L => expected_outputs(i)%outputs(), &
-            z_L => actual_outputs%pre_activation_out(), &
-            z => actual_outputs%pre_activation_in(), &
-            w_L => self%output_weights(), &
-            w => self%hidden_weights(), &
-            w_in => self%input_weights() &
+            expected_outputs => input_output_pairs%expected_outputs(), &
+            inputs => input_output_pairs%inputs() &
           )
-            associate( &
-                a => self%differentiable_activation_strategy_%activation(z), &
-                sigma_prime_of_z_L => self%differentiable_activation_strategy_%activation_derivative(z_L), &
-                sigma_prime_of_z => self%differentiable_activation_strategy_%activation_derivative(z) &
-            )
-              associate(delta_L => (a_L - y_L)*sigma_prime_of_z_L)
+            if (allocated(network_increments)) deallocate(network_increments)
+            allocate(network_increments(size(inputs)))
+            if (allocated(actual_outputs)) deallocate(actual_outputs)
+            allocate(actual_outputs(size(inputs)))
 
-                delta(:,num_hidden_layers) = matmul(transpose(w_L), delta_L) * sigma_prime_of_z(:,num_hidden_layers)
+            loop_over_input_ouput_pairs: &
+            do concurrent(pair = 1:size(inputs))
 
-                do l = num_hidden_layers-1 , 1, -1
-                  delta(:,l) = matmul(transpose(w(:,:,l+1)), delta(:,l+1)) * sigma_prime_of_z(:,l)
-                end do
+              actual_outputs(pair) = self%infer(inputs(pair), inference_strategy) 
 
-                block
-                  real(rkind), parameter :: eta = 1. ! training rate
+              associate( &
+                a_L => actual_outputs(pair)%outputs(), &
+                y_L => expected_outputs(pair)%outputs(), &
+                z_L => actual_outputs(pair)%pre_activation_out(), &
+                z => actual_outputs(pair)%pre_activation_in(), &
+                w_L => self%output_weights(), &
+                w => self%hidden_weights(), &
+                w_in => self%input_weights() &
+              )
+                associate( &
+                    a => self%differentiable_activation_strategy_%activation(z), &
+                    sigma_prime_of_z_L => self%differentiable_activation_strategy_%activation_derivative(z_L), &
+                    sigma_prime_of_z => self%differentiable_activation_strategy_%activation_derivative(z) &
+                )
+                  associate(delta_L => (a_L - y_L)*sigma_prime_of_z_L)
 
-                  do concurrent(l = 1:size(delta_w,3))
-                    delta_w(:,:,l) = -eta*outer_product(delta(:,l+1), a(:,l))
-                  end do
+                    delta(:,num_hidden_layers) = matmul(transpose(w_L), delta_L) * sigma_prime_of_z(:,num_hidden_layers)
 
-                  call self%increment( &
-                    delta_w_in =  -eta*outer_product(delta(:,1), inputs(i)%inputs()), &
-                    delta_w_hidden = delta_w, &
-                    delta_w_out = -eta*outer_product(delta_L, a(:,num_hidden_layers)), &
-                    delta_b_hidden = -eta*delta, &
-                    delta_b_out = -eta*delta_L &
-                  )
-                end block
+                    do l = num_hidden_layers-1 , 1, -1
+                      delta(:,l) = matmul(transpose(w(:,:,l+1)), delta(:,l+1)) * sigma_prime_of_z(:,l)
+                    end do
+
+                    block
+                      real(rkind), parameter :: eta = 1. ! training rate
+
+                      do concurrent(l = 1:size(delta_w,3))
+                        delta_w(:,:,l) = -eta*outer_product(delta(:,l+1), a(:,l))
+                      end do
+
+                      network_increments(pair) = network_increment_t( &
+                        delta_w_in =  -eta*outer_product(delta(:,1), inputs(pair)%inputs()), &
+                        delta_w_hidden = delta_w, &
+                        delta_w_out = -eta*outer_product(delta_L, a(:,num_hidden_layers)), &
+                        delta_b_hidden = -eta*delta, &
+                        delta_b_out = -eta*delta_L &
+                      )
+                    end block
+                  end associate
+                end associate
               end associate
-            end associate
+            end do loop_over_input_ouput_pairs
+
+            call self%increment( .average. network_increments)
+
           end associate
-        end do
-      end associate
+        end associate
+      end do loop_over_mini_batches
     end associate
 
   contains

--- a/src/inference_engine/trainable_engine_s.f90
+++ b/src/inference_engine/trainable_engine_s.f90
@@ -1,11 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(trainable_engine_m) trainable_engine_s
-  use assert_m, only : assert
-  use intrinsic_array_m, only : intrinsic_array_t
   use outputs_m, only : outputs_t
-  use expected_outputs_m, only : expected_outputs_t
-  use input_output_pair_m, only : input_output_pair_t
   implicit none
 
 contains
@@ -18,60 +14,63 @@ contains
 
     call self%assert_consistent
 
-    associate( &
-      num_hidden_layers => self%num_hidden_layers(), &
-      neurons_per_layer => self%neurons_per_layer(), &
-      expected_outputs => input_output_pairs%expected_outputs(), &
-      inputs => input_output_pairs%inputs() &
-    )
-      allocate(delta(neurons_per_layer, num_hidden_layers))
-      allocate(delta_w(neurons_per_layer, neurons_per_layer, num_hidden_layers-1))
+    associate(input_output_pairs => mini_batch%input_output_pairs())
 
-      do i = 1, size(inputs)
+      associate( &
+        num_hidden_layers => self%num_hidden_layers(), &
+        neurons_per_layer => self%neurons_per_layer(), &
+        expected_outputs => input_output_pairs%expected_outputs(), &
+        inputs => input_output_pairs%inputs() &
+      )
+        allocate(delta(neurons_per_layer, num_hidden_layers))
+        allocate(delta_w(neurons_per_layer, neurons_per_layer, num_hidden_layers-1))
 
-        actual_outputs = self%infer(input_output_pairs(i)%inputs(), inference_strategy) 
+        do i = 1, size(inputs)
 
-        associate( &
-          a_L => actual_outputs%outputs(), &
-          y_L => expected_outputs(i)%outputs(), &
-          z_L => actual_outputs%pre_activation_out(), &
-          z => actual_outputs%pre_activation_in(), &
-          w_L => self%output_weights(), &
-          w => self%hidden_weights(), &
-          w_in => self%input_weights() &
-        )
+          actual_outputs = self%infer(inputs(i), inference_strategy) 
+
           associate( &
-              a => self%differentiable_activation_strategy_%activation(z), &
-              sigma_prime_of_z_L => self%differentiable_activation_strategy_%activation_derivative(z_L), &
-              sigma_prime_of_z => self%differentiable_activation_strategy_%activation_derivative(z) &
+            a_L => actual_outputs%outputs(), &
+            y_L => expected_outputs(i)%outputs(), &
+            z_L => actual_outputs%pre_activation_out(), &
+            z => actual_outputs%pre_activation_in(), &
+            w_L => self%output_weights(), &
+            w => self%hidden_weights(), &
+            w_in => self%input_weights() &
           )
-            associate(delta_L => (a_L - y_L)*sigma_prime_of_z_L)
+            associate( &
+                a => self%differentiable_activation_strategy_%activation(z), &
+                sigma_prime_of_z_L => self%differentiable_activation_strategy_%activation_derivative(z_L), &
+                sigma_prime_of_z => self%differentiable_activation_strategy_%activation_derivative(z) &
+            )
+              associate(delta_L => (a_L - y_L)*sigma_prime_of_z_L)
 
-              delta(:,num_hidden_layers) = matmul(transpose(w_L), delta_L) * sigma_prime_of_z(:,num_hidden_layers)
+                delta(:,num_hidden_layers) = matmul(transpose(w_L), delta_L) * sigma_prime_of_z(:,num_hidden_layers)
 
-              do l = num_hidden_layers-1 , 1, -1
-                delta(:,l) = matmul(transpose(w(:,:,l+1)), delta(:,l+1)) * sigma_prime_of_z(:,l)
-              end do
-
-              block
-                real(rkind), parameter :: eta = 1. ! training rate
-
-                do concurrent(l = 1:size(delta_w,3))
-                  delta_w(:,:,l) = -eta*outer_product(delta(:,l+1), a(:,l))
+                do l = num_hidden_layers-1 , 1, -1
+                  delta(:,l) = matmul(transpose(w(:,:,l+1)), delta(:,l+1)) * sigma_prime_of_z(:,l)
                 end do
 
-                call self%increment( &
-                  delta_w_in =  -eta*outer_product(delta(:,1), inputs(i)%inputs()), &
-                  delta_w_hidden = delta_w, &
-                  delta_w_out = -eta*outer_product(delta_L, a(:,num_hidden_layers)), &
-                  delta_b_hidden = -eta*delta, &
-                  delta_b_out = -eta*delta_L &
-                )
-              end block
+                block
+                  real(rkind), parameter :: eta = 1. ! training rate
+
+                  do concurrent(l = 1:size(delta_w,3))
+                    delta_w(:,:,l) = -eta*outer_product(delta(:,l+1), a(:,l))
+                  end do
+
+                  call self%increment( &
+                    delta_w_in =  -eta*outer_product(delta(:,1), inputs(i)%inputs()), &
+                    delta_w_hidden = delta_w, &
+                    delta_w_out = -eta*outer_product(delta_L, a(:,num_hidden_layers)), &
+                    delta_b_hidden = -eta*delta, &
+                    delta_b_out = -eta*delta_L &
+                  )
+                end block
+              end associate
             end associate
           end associate
-        end associate
-      end do
+        end do
+      end associate
     end associate
 
   contains

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -8,6 +8,7 @@ module inference_engine_m
  use kind_parameters_m
  use layer_m
  use matmul_m
+ use mini_batch_m
  use input_output_pair_m
  use neuron_m
  use outputs_m

--- a/test/main.f90
+++ b/test/main.f90
@@ -2,22 +2,22 @@
 ! Terms of use are as specified in LICENSE.txt
 program main
   use inference_engine_test_m, only : inference_engine_test_t  
-  use trainable_engine_test_m, only : trainable_engine_test_t  
   use asymmetric_engine_test_m, only : asymmetric_engine_test_t  
   use skip_connections_test_m, only : skip_connections_test_t  
+  use trainable_engine_test_m, only : trainable_engine_test_t  
   implicit none
 
   type(inference_engine_test_t) inference_engine_test
-  type(trainable_engine_test_t) trainable_engine_test
   type(asymmetric_engine_test_t) asymmetric_engine_test
   type(skip_connections_test_t) skip_connections_test
+  type(trainable_engine_test_t) trainable_engine_test
 
   integer :: passes=0, tests=0
 
   call inference_engine_test%report(passes, tests)
-  call trainable_engine_test%report(passes, tests)
   call asymmetric_engine_test%report(passes, tests)
   call skip_connections_test%report(passes, tests)
+  call trainable_engine_test%report(passes, tests)
 
   print *
   print '(*(a,:,g0))',"_________ In total, ",passes," of ",tests, " tests pass. _________"


### PR DESCRIPTION
- [X] Add `mini_batch_t` type and accept an object of this type as an argument to `train`
- [X] Add `network_increment_t`
- [x] Compute an average increment for a mini-batch
- [x] Add unit test for training from an array of mini-batches 