### PR TITLE
Feature: 1st converging cloud microphysics model

### DIFF
--- a/app/train-cloud-microphysics.f90
+++ b/app/train-cloud-microphysics.f90
@@ -179,7 +179,7 @@ contains
       type(bin_t), allocatable :: bins(:)
       type(input_output_pair_t), allocatable :: input_output_pairs(:)
       type(tensor_t), allocatable, dimension(:) :: inputs, outputs
-      real(rkind), parameter :: keep = 0.3
+      real(rkind), parameter :: keep = 0.01
       real(rkind), allocatable :: cost(:)
       real(rkind), allocatable :: harvest(:)
       integer, parameter :: mini_batch_size=1
@@ -194,7 +194,7 @@ contains
       else
         close(network_unit)
         print *,"Initializing a new network"
-        trainable_engine = new_engine(num_hidden_layers=12, nodes_per_hidden_layer=16, num_inputs=8, num_outputs=6, random=.false.)
+        trainable_engine = new_engine(num_hidden_layers=6, nodes_per_hidden_layer=16, num_inputs=8, num_outputs=6, random=.false.)
       end if
       
       print *,"Defining tensors from time steps 1 through", t_end, "with strides of", stride

--- a/app/train-cloud-microphysics.f90
+++ b/app/train-cloud-microphysics.f90
@@ -246,7 +246,6 @@ contains
           open(newunit=network_unit, file=network_file, form='formatted', status='unknown', iostat=io_status, action='write')
           associate(inference_engine => trainable_engine%to_inference_engine())
             associate(json_file => inference_engine%to_json())
-              print *,"Writing network to " // network_file
               call json_file%write_lines(string_t(network_file))
             end associate
           end associate

--- a/app/train-cloud-microphysics.f90
+++ b/app/train-cloud-microphysics.f90
@@ -48,7 +48,7 @@ program train_cloud_microphysics
   type(string_t), allocatable :: lines(:)
   character(len=*), parameter :: plot_file_name = "cost.plt"
   character(len=:), allocatable :: base_name, stride_string, epochs_string, last_line
-  integer plot_unit, stride, starting_epoch, ending_epoch, num_epochs, last_epoch_in_file
+  integer plot_unit, stride, num_epochs, previous_epoch
   logical preexisting_plot_file
 
   call system_clock(t_start, clock_rate)
@@ -68,16 +68,13 @@ program train_cloud_microphysics
 
   if (.not. preexisting_plot_file) then
     write(plot_unit,*) "      Epoch   Cost (min)       Cost (max)       Cost (avg)"
-    starting_epoch = 1
+    previous_epoch = 0
   else
     plot_file = file_t(string_t(plot_file_name))
     lines = plot_file%lines()
     last_line = lines(size(lines))%string()
-    read(last_line,*) last_epoch_in_file
-    starting_epoch = last_epoch_in_file + 1
+    read(last_line,*) previous_epoch
   end if
-
-  ending_epoch = starting_epoch + num_epochs - 1
 
   call read_train_write
 
@@ -238,7 +235,7 @@ contains
         print *,"Training network"
         print *, "       Epoch   Cost (min)       Cost (max)       Cost (avg)"
 
-        do epoch = starting_epoch, ending_epoch
+        do epoch = previous_epoch + 1, previous_epoch + num_epochs
 
           call shuffle(input_output_pairs) ! set up for stochastic gradient descent
           mini_batches = [(mini_batch_t(input_output_pairs(bins(b)%first():bins(b)%last())), b = 1, size(bins))]

--- a/app/train-cloud-microphysics.f90
+++ b/app/train-cloud-microphysics.f90
@@ -194,7 +194,7 @@ contains
       else
         close(network_unit)
         print *,"Initializing a new network"
-        trainable_engine = new_engine(num_hidden_layers=12, nodes_per_hidden_layer=16, num_inputs=8, num_outputs=6, random=.true.)
+        trainable_engine = new_engine(num_hidden_layers=12, nodes_per_hidden_layer=16, num_inputs=8, num_outputs=6, random=.false.)
       end if
       
       print *,"Defining tensors from time steps 1 through", t_end, "with strides of", stride
@@ -229,7 +229,7 @@ contains
       end associate
 
 
-      associate(num_pairs => size(input_output_pairs), n_bins => size(input_output_pairs)/10000)
+      associate(num_pairs => size(input_output_pairs), n_bins => 1) ! also tried n_bins => size(input_output_pairs)/10000
         bins = [(bin_t(num_items=num_pairs, num_bins=n_bins, bin_number=b), b = 1, n_bins)]
 
         print *,"Training network"

--- a/example/print-network-properties.f90
+++ b/example/print-network-properties.f90
@@ -25,7 +25,10 @@ program read_json
   inference_engine = inference_engine_t(file_t(input_file_name))
   print *, "number of inputs: ", inference_engine%num_inputs()
   print *, "number of outputs: ", inference_engine%num_outputs()
-  print *, "number of nodes per layer: ", inference_engine%nodes_per_layer()
+  associate(nodes => inference_engine%nodes_per_layer())
+    print *, "number of layers: ", size(nodes) 
+    print *, "number of nodes per layer: ", nodes 
+  end associate
   activation_name = inference_engine%activation_function_name()
   print *, "activation function: ", activation_name%string()
   print *, "using skip connections: ", merge("true ", "false", inference_engine%skip())

--- a/src/inference_engine/trainable_engine_s.f90
+++ b/src/inference_engine/trainable_engine_s.f90
@@ -82,7 +82,7 @@ contains
 
   module procedure train
     integer l, batch, mini_batch_size, pair
-    real(rkind), parameter :: eta = 1.5e0 ! Learning parameter
+    real(rkind), parameter :: eta = 3.e0 ! Learning parameter
     real(rkind), allocatable :: &
       z(:,:), a(:,:), delta(:,:), dcdw(:,:,:), dcdb(:,:), vdw(:,:,:), sdw(:,:,:), vdb(:,:), sdb(:,:), vdwc(:,:,:), sdwc(:,:,:), &
       vdbc(:,:), sdbc(:,:)


### PR DESCRIPTION
This pull request exhibits nearly monotonic convergence as measured by the cost function decreasing 3 orders of magnitude in the first 120 epochs:

![here](https://github.com/BerkeleyLab/inference-engine/files/12579898/cost.pdf)

To reproduce this behavior, execute
```
./build/run-fpm.sh run -- --base training --epochs 120 --stride 720
```
with the present working directory containing the 29.7 GB training_input.nc and training_output.nc produced for the "Colorado benchmark simulation" using commit d7aa958 on the neural-net branch of https://github.com/berkeleylab/icar, which uses the simplest of ICAR's cloud microphysics models.  The Inference-Engine run uses

* A single time instant (as determined by the above stride),
* A 30% retention rate of grid points where time derivatives vanish,
* Zero initial weights and biases,
* A batch size equal to the entire time instant,
* Gradient descent with no optimizer, and
* A single mini-batch.

The program shuffles the data set in order to facilitate stochastic gradient descent. However, because a single mini-batch is used, the cost function is computed across the entire data set, which negates the value of shuffling and thus presumably makes this gradient descent.

Because a single time instant is used, this case reflects the behavior that might be expected if Inference-Engine is integrated into ICAR and training happens during an ICAR run.  In such a scenario, it might be desirable to iterate on each time instant as soon as the time step completes.  Doing so might either be used to

* Pretrain the network to promote faster convergence during a subsequent training session after the ICAR run using data saved from the run or
* Obviate the need for saving large training data sets for subsequent training.
