### PR TITLE
test(train):test near radius of non-convergence

### DIFF
--- a/src/inference_engine/input_output_pair_m.f90
+++ b/src/inference_engine/input_output_pair_m.f90
@@ -7,6 +7,7 @@ module input_output_pair_m
 
   private
   public :: input_output_pair_t
+  public :: shuffle
 
   type input_output_pair_t
     private
@@ -39,6 +40,12 @@ module input_output_pair_m
       class(input_output_pair_t), intent(in) :: self
       type(tensor_t) :: my_expected_outputs
     end function
+
+    pure module subroutine shuffle(pairs, random_numbers)
+      implicit none
+      type(input_output_pair_t), intent(inout) :: pairs(:)
+      real, intent(in) :: random_numbers(2:)
+    end subroutine
 
   end interface
 

--- a/src/inference_engine/input_output_pair_s.f90
+++ b/src/inference_engine/input_output_pair_s.f90
@@ -1,6 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(input_output_pair_m) input_output_pair_s
+  use assert_m, only : assert
   implicit none
 
 contains
@@ -16,6 +17,22 @@ contains
 
   module procedure expected_outputs
     my_expected_outputs = self%expected_outputs_
+  end procedure
+
+  module procedure shuffle
+    type(input_output_pair_t) temp
+    integer i, j
+
+    call assert(size(random_numbers) >= size(pairs)-1, "input_output_pair_s(shuffle): size(random_numbers) >= size(pairs)-1")
+
+    durstenfeld_shuffle: &
+    do i = size(pairs), 2, -1
+      j = 1 + int(random_numbers(i)*i)
+      temp     = pairs(i)
+      pairs(i) = pairs(j)
+      pairs(j) = temp
+    end do durstenfeld_shuffle
+
   end procedure
 
 end submodule input_output_pair_s

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -4,7 +4,7 @@ module inference_engine_m
  !! Specify the user-facing modules, derived types, and type parameters
  use activation_strategy_m, only : activation_strategy_t
  use differentiable_activation_strategy_m, only : differentiable_activation_strategy_t
- use input_output_pair_m, only : input_output_pair_t
+ use input_output_pair_m, only : input_output_pair_t, shuffle
  use inference_engine_m_, only : inference_engine_t, difference_t
  use kind_parameters_m, only : rkind
  use mini_batch_m, only : mini_batch_t


### PR DESCRIPTION
In this pull request, the `perturbed_identity_converges()` test function executes at four parameters' threshold values required for training to converge:

Parameter        | Description                                                                   | Threshold or Required
---------------|----------------------------------------------------|-------------------
num_ephochs  | # passes through the full data set                              | 148
num_bins         | # mini-batches into which the data set is divided     | 5
stochastic        | whether a subroutine shuffles the data each epoch | yes
adam                | whether the Adam optimizer is used                          | yes

For the tested data set of size `num_pairs=6`, decrementing `num_epochs` or `num_bins` or not using stochastic gradient descent or the Adam optimizer causes the training to not converge to within the error tolerance employed: `1.E-06`.