### PR TITLE
Train linear combinations of inputs

### DIFF
--- a/example/fit-polynomials.f90
+++ b/example/fit-polynomials.f90
@@ -1,0 +1,137 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+program train_polynomials
+  !! This trains a neural network to learn the following six polynomial functions of its eight inputs.
+  use inference_engine_m, only : &
+    inference_engine_t, trainable_engine_t, mini_batch_t, tensor_t, input_output_pair_t, shuffle, relu_t
+  use sourcery_m, only : string_t, file_t, command_line_t, bin_t
+  use assert_m, only : assert, intrinsic_array_t
+  implicit none
+
+  type(string_t) intial_network_file, final_network_file
+  type(command_line_t) command_line
+
+  final_network_file = string_t(command_line%flag_value("--output-file"))
+
+  if (len(final_network_file%string())==0) then
+    error stop new_line('a') // new_line('a') // &
+      'Usage: ./build/run-fpm.sh run --example train-polynomials -- --output-file "<file-name>"' 
+  end if
+
+  block
+    integer, parameter :: num_pairs = 5, num_epochs = 500, num_mini_batches= 3 ! num_pairs =  # input/output pairs in training data
+
+    type(mini_batch_t), allocatable :: mini_batches(:)
+    type(input_output_pair_t), allocatable :: input_output_pairs(:)
+    type(tensor_t), allocatable :: inputs(:), desired_outputs(:)
+    type(trainable_engine_t)  trainable_engine
+    type(bin_t), allocatable :: bins(:)
+    real, allocatable :: cost(:), random_numbers(:)
+
+    call random_init(image_distinct=.true., repeatable=.true.)
+
+    trainable_engine = perturbed_identity_network(perturbation_magnitude=0.1)
+    call output(trainable_engine%to_inference_engine(), string_t("initial-network.json"))
+
+    associate(num_inputs => trainable_engine%num_inputs(), num_outputs => trainable_engine%num_outputs())
+
+      block
+        integer i, j
+        inputs = [(tensor_t(real([(j*i, j = 1,num_inputs)])/(num_inputs*num_pairs)), i = 1, num_pairs)]
+        desired_outputs = y(inputs)
+        call assert(num_outputs == size(desired_outputs(1)%values()), &
+          "fit-polynomials: # outputs", intrinsic_array_t([num_outputs,  size(desired_outputs(1)%values())]) &
+         )
+      end block
+      input_output_pairs = input_output_pair_t(inputs, desired_outputs)
+      block 
+        integer b
+        bins = [(bin_t(num_items=num_pairs, num_bins=num_mini_batches, bin_number=b), b = 1, num_mini_batches)]
+      end block
+
+      allocate(random_numbers(2:size(input_output_pairs)))
+
+      print *,"Cost"
+      block
+        integer e, b
+        do e = 1,num_epochs
+          call random_number(random_numbers)
+          call shuffle(input_output_pairs, random_numbers)
+          mini_batches = [(mini_batch_t(input_output_pairs(bins(b)%first():bins(b)%last())), b = 1, size(bins))]
+          call trainable_engine%train(mini_batches, cost, adam=.true.)
+          print *,sum(cost)/size(cost)
+        end do
+      end block
+
+      block
+        real, parameter :: tolerance = 1.E-06
+        integer p
+
+        associate(network_outputs => trainable_engine%infer(inputs))
+          print *," Outputs                                             | Desired outputs"
+          do p = 1, num_pairs
+            print *,network_outputs(p)%values(),                       "|", desired_outputs(p)%values()
+          end do
+        end associate
+      end block
+
+   end associate
+
+   call output(trainable_engine%to_inference_engine(), final_network_file)
+
+  end block
+
+contains
+
+  subroutine output(inference_engine, file_name)
+    type(inference_engine_t), intent(in) :: inference_engine
+    type(string_t), intent(in) :: file_name
+    type(file_t) json_file
+    json_file = inference_engine%to_json()
+    call json_file%write_lines(file_name)
+  end subroutine
+
+  pure function e(j,n) result(unit_vector)
+    integer, intent(in) :: j, n
+    integer k
+    real, allocatable :: unit_vector(:)
+    unit_vector = real([(merge(1,0,j==k),k=1,n)])
+  end function
+
+  elemental function y(x_tensor) result(a_tensor)
+    type(tensor_t), intent(in) :: x_tensor
+    type(tensor_t) a_tensor
+    associate(x => x_tensor%values())
+      call assert(ubound(x,1)>=7 .and. lbound(x,1)<=2,"y(x) :: sufficient input")
+      a_tensor = tensor_t([x(1), x(2) + x(3), x(4), x(5), 0.5*x(6) + 1.5*x(7), x(8)])
+    end associate
+  end function
+
+  function perturbed_identity_network(perturbation_magnitude) result(trainable_engine)
+    type(trainable_engine_t) trainable_engine
+    real, intent(in) :: perturbation_magnitude
+    integer, parameter :: n(*) = [8, 8, 8, 8, 6]
+    integer, parameter :: n_max = maxval(n), layers = size(n)
+    integer j, k, l
+    real, allocatable :: identity(:,:,:), w_harvest(:,:,:), b_harvest(:,:)
+
+    identity =  reshape( [( [(e(k,n_max), k=1,n_max)], l = 1, layers-1 )], [n_max, n_max, layers-1])
+
+    allocate(w_harvest, mold = identity)
+    allocate(b_harvest(size(identity,1), size(identity,3)))
+
+    call random_number(w_harvest)
+    call random_number(b_harvest)
+
+    associate(w => identity + perturbation_magnitude*(w_harvest-0.5)/0.5, b => perturbation_magnitude*(b_harvest-0.5)/0.5)
+
+      trainable_engine = trainable_engine_t( &
+        nodes = n, weights = w, biases = b, differentiable_activation_strategy = relu_t(), &
+        metadata = &
+          [string_t("Perturbed Identity"), string_t("Damian Rouson"), string_t("2023-09-23"), string_t("relu"), string_t("false")] &
+      )
+
+    end associate
+  end function
+
+end program

--- a/example/train-and-write.f90
+++ b/example/train-and-write.f90
@@ -45,8 +45,8 @@ program train_and_write
         intrinsic_array_t([num_inputs, num_outputs]) &
       )
       block
-        integer i
-        inputs = [(tensor_t(real([i,2*i])/(2*num_pairs)), i = 1, num_pairs)]
+        integer i, j
+        inputs = [(tensor_t(real([(j*i, j = 1,num_inputs)])/(num_inputs*num_pairs)), i = 1, num_pairs)]
       end block
       associate(outputs => inputs)
         input_output_pairs = input_output_pair_t(inputs, outputs)
@@ -75,9 +75,11 @@ program train_and_write
         integer p
 
         associate(network_outputs => trainable_engine%infer(inputs))
-          print *,"Outputs                           |   Desired outputs"
+          print *," Outputs                          |&
+                   Desired outputs                    |&
+                   Errors"
           do p = 1, num_pairs
-            print *,network_outputs(p)%values(),    "|", inputs(p)%values()
+            print *,network_outputs(p)%values(),"|", inputs(p)%values(), "|",  network_outputs(p)%values() - inputs(p)%values()
           end do
         end associate
       end block
@@ -103,8 +105,9 @@ contains
     real, intent(in) :: perturbation_magnitude
     integer, parameter :: nodes_per_layer(*) = [2, 2, 2, 2]
     integer, parameter :: max_n = maxval(nodes_per_layer), layers = size(nodes_per_layer)
+    integer i
     real, parameter :: identity(*,*,*) = &
-      reshape([real:: [1,0], [0,1] ,[1,0], [0,1], [1,0], [0,1]], [max_n, max_n, layers-1])
+      reshape(real([( [1,0], [0,1], i=1,layers-1 )]), [max_n, max_n, layers-1])
     real w_harvest(size(identity,1), size(identity,2), size(identity,3)), b_harvest(size(identity,1), size(identity,3))
 
     call random_number(w_harvest)

--- a/example/train-and-write.f90
+++ b/example/train-and-write.f90
@@ -34,6 +34,8 @@ program train_and_write
     type(bin_t), allocatable :: bins(:)
     real, allocatable :: cost(:), random_numbers(:)
 
+    call random_init(image_distinct=.true., repeatable=.true.)
+
     trainable_engine = perturbed_identity_network(perturbation_magnitude=0.1)
     call output(trainable_engine%to_inference_engine(), string_t("initial-network.json"))
 

--- a/example/train-and-write.f90
+++ b/example/train-and-write.f90
@@ -1,91 +1,120 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 program train_and_write
-  !! This program demonstrates how to train a neural network and write it to a JSON file.
+  !! This program demonstrates how to train a simple neural network starting from a randomized initial condition and 
+  !! how to write the initial network and the trained network to separate JSON files.  The network has two hiden layers.
+  !! The input, hidden, and output layers are all two nodes wide.  The training data has outputs that identically match
+  !! the corresponding inputs.  Hence, the desired network represents an identity mapping.  With RELU activation functions,
+  !! the desired network therefore contains weights corresponding to identity matrices and biases that vanish everywhere.
+  !! The initial condition corresponds to the desired network with all weights and biases perturbed by a random variable
+  !! that is uniformly distributed on the range [0,0.1].
   use inference_engine_m, only : &
-    inference_engine_t, trainable_engine_t, rkind, sigmoid_t, mini_batch_t, tensor_t, input_output_pair_t
-  use sourcery_m, only : string_t, file_t, command_line_t
+    inference_engine_t, trainable_engine_t, mini_batch_t, tensor_t, input_output_pair_t, shuffle, relu_t
+  use sourcery_m, only : string_t, file_t, command_line_t, bin_t
+  use assert_m, only : assert, intrinsic_array_t
   implicit none
 
-  type(string_t) file_name
+  type(string_t) intial_network_file, final_network_file
   type(command_line_t) command_line
-  real(rkind), parameter :: false=0._rkind, true=1._rkind
 
-  file_name = string_t(command_line%flag_value("--output-file"))
+  final_network_file = string_t(command_line%flag_value("--output-file"))
 
-  if (len(file_name%string())==0) then
+  if (len(final_network_file%string())==0) then
     error stop new_line('a') // new_line('a') // &
       'Usage: ./build/run-fpm.sh run --example train-and-write -- --output-file "<file-name>"' 
   end if
 
-  and_gate_with_skewed_training_data: &
   block
-    logical, allocatable :: test_passes(:)
+    integer, parameter :: num_pairs = 5, num_epochs = 100, num_mini_batches= 3 ! num_pairs =  # input/output pairs in training data
+
     type(mini_batch_t), allocatable :: mini_batches(:)
-    type(tensor_t), allocatable, dimension(:,:) :: training_inputs, training_outputs
-    type(tensor_t), allocatable, dimension(:) :: tmp, tmp2, test_inputs, expected_test_outputs, actual_outputs
-    type(trainable_engine_t) trainable_engine
-    type(inference_engine_t) inference_engine
-    real(rkind), parameter :: tolerance = 1.E-02_rkind
-    real(rkind), allocatable :: harvest(:,:,:)
-    integer, parameter :: num_inputs=2, mini_batch_size = 1, num_iterations=20000
-    integer batch, iter, i
-    type(file_t) json_file
+    type(input_output_pair_t), allocatable :: input_output_pairs(:)
+    type(tensor_t), allocatable :: inputs(:)
+    type(trainable_engine_t)  trainable_engine
+    type(bin_t), allocatable :: bins(:)
+    real, allocatable :: cost(:), random_numbers(:)
 
-    allocate(harvest(num_inputs, mini_batch_size, num_iterations))
-    call random_number(harvest)
-    harvest = 2.*(harvest - 0.5) ! skew toward more input values being true
+    trainable_engine = perturbed_identity_network(perturbation_magnitude=0.1)
+    call output(trainable_engine%to_inference_engine(), string_t("initial-network.json"))
 
-    ! The following temporary copies are required by gfortran bug 100650 and possibly 49324
-    ! See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100650 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49324
-    tmp = [([(tensor_t(merge(true, false, harvest(:,batch,iter) < 0.5E0)), batch=1, mini_batch_size)], iter=1, num_iterations)]
-    training_inputs = reshape(tmp, [mini_batch_size, num_iterations])
+    associate(num_inputs => trainable_engine%num_inputs(), num_outputs => trainable_engine%num_outputs())
 
-    tmp2 = [([(and(training_inputs(batch, iter)), batch = 1, mini_batch_size)], iter = 1, num_iterations )]
-    training_outputs = reshape(tmp2, [mini_batch_size, num_iterations])
+      call assert(num_inputs == num_outputs,"trainable_engine_test_m(identity_mapping): # inputs == # outputs", &
+        intrinsic_array_t([num_inputs, num_outputs]) &
+      )
+      block
+        integer i
+        inputs = [(tensor_t(real([i,2*i])/(2*num_pairs)), i = 1, num_pairs)]
+      end block
+      associate(outputs => inputs)
+        input_output_pairs = input_output_pair_t(inputs, outputs)
+      end associate
+      block 
+        integer b
+        bins = [(bin_t(num_items=num_pairs, num_bins=num_mini_batches, bin_number=b), b = 1, num_mini_batches)]
+      end block
 
-    mini_batches = [(mini_batch_t(input_output_pair_t(training_inputs(:,iter), training_outputs(:,iter))), iter=1, num_iterations)]    
-    trainable_engine = two_zeroed_hidden_layers()
+      allocate(random_numbers(2:size(input_output_pairs)))
 
-    call trainable_engine%train(mini_batches,adam=.true.)
+      print *,"Cost"
+      block
+        integer e, b
+        do e = 1,num_epochs
+          call random_number(random_numbers)
+          call shuffle(input_output_pairs, random_numbers)
+          mini_batches = [(mini_batch_t(input_output_pairs(bins(b)%first():bins(b)%last())), b = 1, size(bins))]
+          call trainable_engine%train(mini_batches, cost, adam=.true.)
+          print *,sum(cost)/size(cost)
+        end do
+      end block
 
-    test_inputs = [tensor_t([true,true]), tensor_t([false,true]), tensor_t([true,false]), tensor_t([false,false])]
-    expected_test_outputs = [(and(test_inputs(i)), i=1, size(test_inputs))]
-    actual_outputs = trainable_engine%infer(test_inputs)
+      block
+        real, parameter :: tolerance = 1.E-06
+        integer p
 
-    print *,"  Input 1          Input 2         Expected output   Actual output"
-    do i = 1, size(test_inputs)
-       print *, test_inputs(i)%values(), actual_outputs(i)%values(), expected_test_outputs(i)%values()
-    end do
+        associate(network_outputs => trainable_engine%infer(inputs))
+          print *,"Outputs                           |   Desired outputs"
+          do p = 1, num_pairs
+            print *,network_outputs(p)%values(),    "|", inputs(p)%values()
+          end do
+        end associate
+      end block
 
-    inference_engine = trainable_engine%to_inference_engine()
-    json_file = inference_engine%to_json()
-    call json_file%write_lines(file_name)
+   end associate
 
-  end block and_gate_with_skewed_training_data
+   call output(trainable_engine%to_inference_engine(), final_network_file)
+
+  end block
 
 contains
 
-  elemental function and(inputs_object) result(expected_outputs_object)
-    type(tensor_t), intent(in) :: inputs_object 
-    type(tensor_t) expected_outputs_object 
-    expected_outputs_object = tensor_t([merge(true, false, sum(inputs_object%values()) > 1.99_rkind)])
-  end function
+  subroutine output(inference_engine, file_name)
+    type(inference_engine_t), intent(in) :: inference_engine
+    type(string_t), intent(in) :: file_name
+    type(file_t) json_file
+    json_file = inference_engine%to_json()
+    call json_file%write_lines(file_name)
+  end subroutine
 
-  function two_zeroed_hidden_layers() result(trainable_engine)
+  function perturbed_identity_network(perturbation_magnitude) result(trainable_engine)
     type(trainable_engine_t) trainable_engine
-    integer, parameter :: inputs = 2, outputs = 1, hidden = 3 ! number of neurons in input, output, and hidden layers
-    integer, parameter :: neurons(*) = [inputs, hidden, hidden, outputs] ! neurons per layer
-    integer, parameter :: max_neurons = maxval(neurons), layers=size(neurons) ! max layer width, number of layers
-    real(rkind) w(max_neurons, max_neurons, layers-1), b(max_neurons, max_neurons)
+    real, intent(in) :: perturbation_magnitude
+    integer, parameter :: nodes_per_layer(*) = [2, 2, 2, 2]
+    integer, parameter :: max_n = maxval(nodes_per_layer), layers = size(nodes_per_layer)
+    real, parameter :: identity(*,*,*) = &
+      reshape([real:: [1,0], [0,1] ,[1,0], [0,1], [1,0], [0,1]], [max_n, max_n, layers-1])
+    real harvest(size(identity,1), size(identity,2), size(identity,3))
 
-    w = 0.
-    b = 0.
+    call random_number(harvest)
+    harvest = perturbation_magnitude*harvest
 
     trainable_engine = trainable_engine_t( &
-      nodes = neurons, weights = w, biases = b, differentiable_activation_strategy = sigmoid_t(), metadata = & 
-      [string_t("2-hide|3-wide"), string_t("Damian Rouson"), string_t("2023-06-30"), string_t("sigmoid"), string_t("false")] &
-    )   
+      nodes = nodes_per_layer, &
+      weights = identity + harvest , & 
+      biases = reshape([real:: [0,0], [0,0], [0,0]], [max_n, layers-1]), &
+      differentiable_activation_strategy = relu_t(), &
+      metadata = [string_t("Perturbed Identity"), string_t("Rouson"), string_t("2023-09-18"), string_t("relu"), string_t("false")] &
+    )
   end function
 
 end program


### PR DESCRIPTION
This pull request adds `example/fit-polynomials.f90`, which trains a neural network to learn linear combinations of the inputs.  The neural network learns to map eight inputs, `x(1:8)`, to six outputs corresponding to `y(x) = [x(1), x(2) + x(3), x(4), x(5), 0.5*x(6) + 1.5*x(7), x(8)]`, where the network uses 
* The ReLU activation function,
* An initial condition corresponding to a randomly perturbed identity mapping of the six inputs `x(2:7)`, i.e. `y(x) = [x(2), x(3), x(4), x(5), x(6), x(7)`,
* Two hidden layers with 8 nodes each.