### PR TITLE
Remove module keyword from abstract interface

### DIFF
--- a/src/inference_engine/activation_strategy_m.f90
+++ b/src/inference_engine/activation_strategy_m.f90
@@ -27,7 +27,8 @@ module activation_strategy_m
       real(rkind) y
     end function
 
-    elemental module function function_name_i() result(string)
+    elemental function function_name_i() result(string)
+      import string_t
       implicit none
       type(string_t) string
     end function


### PR DESCRIPTION
`gfortran` accepts the `module` keyword that has been removed in this PR, but `ifx` and `nagfor` do not. NOTE: removing the keyword causes other issues to occur with `ifx` and `nagfor`, but `gfortran` is still able to compile.