### PR TITLE
Nagfor workaround

### DIFF
--- a/test/main.F90
+++ b/test/main.F90
@@ -23,12 +23,12 @@ program main
 #ifndef NAGFOR
   call random_init(image_distinct=.true., repeatable=.true.)
 #endif
-  call inference_engine_test%report(passes, tests)
-  call asymmetric_engine_test%report(passes, tests)
-  call trainable_engine_test%report(passes, tests)
   call hyperparameters_test%report(passes, tests)
   call network_configuration_test%report(passes, tests)
   call training_configuration_test%report(passes, tests)
+  call asymmetric_engine_test%report(passes, tests)
+  call inference_engine_test%report(passes, tests)
+  call trainable_engine_test%report(passes, tests)
   call cpu_time(t_finish)
 
   print *

--- a/test/trainable_engine_test_m.F90
+++ b/test/trainable_engine_test_m.F90
@@ -370,7 +370,14 @@ contains
       call assert(num_inputs == num_outputs,"trainable_engine_test_m(identity_mapping): # inputs == # outputs", &
         intrinsic_array_t([num_inputs, num_outputs]) &
       )
+#ifndef NAGFOR
       inputs = [(tensor_t(real([i,2*i], rkind)/num_pairs), i = 1, num_pairs)]
+#else
+      allocate(inputs(num_pairs))
+      do concurrent(i = 1:num_pairs)
+        inputs(i) = tensor_t(real([i,2*i], rkind)/num_pairs)
+      end do
+#endif
       associate(outputs => inputs)
         input_output_pairs = input_output_pair_t(inputs, outputs)
       end associate
@@ -417,7 +424,14 @@ contains
       call assert(num_inputs == num_outputs,"trainable_engine_test_m(identity_mapping): # inputs == # outputs", &
         intrinsic_array_t([num_inputs, num_outputs]) &
       )
+#ifndef NAGFOR
       inputs = [(tensor_t(real([i,2*i], rkind)/(2*num_pairs)), i = 1, num_pairs)]
+#else
+      allocate(inputs(num_pairs))
+      do concurrent(i = 1:num_pairs)
+        inputs(i) = tensor_t(real([i,2*i], rkind)/num_pairs)
+      end do
+#endif
       associate(outputs => inputs)
         input_output_pairs = input_output_pair_t(inputs, outputs)
       end associate


### PR DESCRIPTION
This PR works around all compile-time issues identified when building with the `nagfor` compiler. This PR contains the first commit that enables the `nagfor` compiler to build all of inference-engine.  Because all tests still pass with `gfortran` 13.2.0, this PR is safe to merge.

### Unit test status with the nagfor compiler:
 * Passing:
    - hyperparameters_test_m
    - network_configuration_test_m
    - training_configuration_test_m
* Failing:
     - inference_engine_test_m
* Crashing:
     - asymmetric_engine_test_m
     - trainable_engine_test_m