### PR TITLE
Feature: Add input/output tensor component ranges to network files

### DIFF
--- a/cloud-microphysics/app/train-cloud-microphysics.f90
+++ b/cloud-microphysics/app/train-cloud-microphysics.f90
@@ -265,10 +265,10 @@ contains
         potential_temperature_in = &
           normalize(potential_temperature_in, minval(potential_temperature_in), maxval(potential_temperature_in))
         temperature_in = normalize(temperature_in, minval(temperature_in), maxval(temperature_in))
-        qv_in = normalize(qv_in, min(minval(qv_in), minval(qv_out)), max(maxval(qv_in), maxval(qv_out)))
-        qc_in = normalize(qc_in, min(minval(qc_in), minval(qc_out)), max(maxval(qc_in), maxval(qc_out)))
-        qr_in = normalize(qr_in, min(minval(qr_in), minval(qr_out)), max(maxval(qr_in), maxval(qr_out)))
-        qs_in = normalize(qs_in, min(minval(qs_in), minval(qs_out)), max(maxval(qs_in), maxval(qs_out)))
+        qv_in = normalize(qv_in, minval(qv_in), maxval(qv_in))
+        qc_in = normalize(qc_in, minval(qc_in), maxval(qc_in))
+        qr_in = normalize(qr_in, minval(qr_in), maxval(qr_in))
+        qs_in = normalize(qs_in, minval(qs_in), maxval(qs_in))
 
         print *,"Normalizing output tensors"
         dpt_dt = normalize(dpt_dt, minval(dpt_dt), maxval(dpt_dt))

--- a/cloud-microphysics/app/train-cloud-microphysics.f90
+++ b/cloud-microphysics/app/train-cloud-microphysics.f90
@@ -12,6 +12,7 @@ program train_cloud_microphysics
   !! External dependencies:
   use sourcery_m, only : string_t, file_t, command_line_t, bin_t
   use assert_m, only : assert, intrinsic_array_t
+  use tensor_range_m, only : tensor_range_t
   use ieee_arithmetic, only : ieee_is_nan
   use iso_fortran_env, only : int64, real64
 
@@ -216,6 +217,7 @@ contains
 
       train_network: &
       block
+        type(tensor_range_t) inputs_range, outputs_range
         type(trainable_engine_t) trainable_engine
         type(mini_batch_t), allocatable :: mini_batches(:)
         type(bin_t), allocatable :: bins(:)
@@ -259,23 +261,22 @@ contains
         end if
 
         if (.not. allocated(end_step)) end_step = t_end
-        
-        print *,"Normalizing input tensors"
-        pressure_in = normalize(pressure_in, minval(pressure_in), maxval(pressure_in))
-        potential_temperature_in = &
-          normalize(potential_temperature_in, minval(potential_temperature_in), maxval(potential_temperature_in))
-        temperature_in = normalize(temperature_in, minval(temperature_in), maxval(temperature_in))
-        qv_in = normalize(qv_in, minval(qv_in), maxval(qv_in))
-        qc_in = normalize(qc_in, minval(qc_in), maxval(qc_in))
-        qr_in = normalize(qr_in, minval(qr_in), maxval(qr_in))
-        qs_in = normalize(qs_in, minval(qs_in), maxval(qs_in))
 
-        print *,"Normalizing output tensors"
-        dpt_dt = normalize(dpt_dt, minval(dpt_dt), maxval(dpt_dt))
-        dqv_dt = normalize(dqv_dt, minval(dqv_dt), maxval(dqv_dt))
-        dqc_dt = normalize(dqc_dt, minval(dqc_dt), maxval(dqc_dt))
-        dqr_dt = normalize(dqr_dt, minval(dqr_dt), maxval(dqr_dt))
-        dqs_dt = normalize(dqs_dt, minval(dqs_dt), maxval(dqs_dt))
+        print *,"Calculating inputs tensor component ranges."
+        inputs_range = tensor_range_t( &
+          layer  = "inputs", &
+          minima = [minval(pressure_in), minval(potential_temperature_in), minval(temperature_in), &
+            minval(qv_in), minval(qc_in), minval(qr_in), minval(qs_in)], &
+          maxima = [maxval(pressure_in), maxval(potential_temperature_in), maxval(temperature_in), &
+            maxval(qv_in), maxval(qc_in), maxval(qr_in), maxval(qs_in)] &
+        )
+
+        print *,"Calculating outputs tensor component ranges."
+        outputs_range = tensor_range_t( &
+          layer  = "outputs", &
+          minima = [minval(dpt_dt), minval(dqv_dt), minval(dqc_dt), minval(dqr_dt), minval(dqs_dt)], &
+          maxima = [maxval(dpt_dt), maxval(dqv_dt), maxval(dqc_dt), maxval(dqr_dt), maxval(dqs_dt)] &
+        )
 
         print *,"Defining tensors from time step", start_step, "through", end_step, "with strides of", stride
 
@@ -287,14 +288,20 @@ contains
             qv_in(lon,lat,level,time), qc_in(lon,lat,level,time), qr_in(lon,lat,level,time), qs_in(lon,lat,level,time) &
           ] &
           ), lon = 1, size(qv_in,1))], lat = 1, size(qv_in,2))], level = 1, size(qv_in,3))], time = start_step, end_step, stride)]
-
+ 
         outputs = [( [( [( [( &
           tensor_t( &
             [dpt_dt(lon,lat,level,time), dqv_dt(lon,lat,level,time), dqc_dt(lon,lat,level,time), dqr_dt(lon,lat,level,time), &
              dqs_dt(lon,lat,level,time) &
             ] &
           ), lon = 1, size(qv_in,1))], lat = 1, size(qv_in,2))], level = 1, size(qv_in,3))], time = start_step, end_step, stride)]
-        
+
+        print *,"Normalizing inputs tensors"
+        inputs = inputs_range%map_to_unit_range(inputs)
+
+        print *,"Normalizing outputs tensors"
+        outputs = outputs_range%map_to_unit_range(outputs)
+
         print *, "Eliminating",int(100*(1.-keep)),"% of the grid points that have all-zero time derivatives"
 
         associate(num_grid_pts => size(outputs))

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -7,6 +7,7 @@ module inference_engine_m_
   use sourcery_string_m, only : string_t
   use kind_parameters_m, only : rkind
   use tensor_m, only : tensor_t
+  use tensor_range_m, only : tensor_range_t
   use differentiable_activation_strategy_m, only :differentiable_activation_strategy_t
   implicit none
 
@@ -22,6 +23,7 @@ module inference_engine_m_
   type inference_engine_t
     !! Encapsulate the minimal information needed to perform inference
     private
+    type(tensor_range_t) inputs_range_, outputs_range_
     type(string_t) metadata_(size(key))
     real(rkind), allocatable :: weights_(:,:,:), biases_(:,:)
     integer, allocatable :: nodes_(:)
@@ -57,11 +59,13 @@ module inference_engine_m_
 
   interface inference_engine_t
 
-    pure module function construct_from_padded_arrays(metadata, weights, biases, nodes) result(inference_engine)
+    pure module function construct_from_padded_arrays(metadata, weights, biases, nodes, inputs_range, outputs_range) &
+      result(inference_engine)
       implicit none
       type(string_t), intent(in) :: metadata(:)
       real(rkind), intent(in) :: weights(:,:,:), biases(:,:)
       integer, intent(in) :: nodes(0:)
+      type(tensor_range_t), intent(in), optional :: inputs_range, outputs_range
       type(inference_engine_t) inference_engine
     end function
 

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -166,7 +166,9 @@ contains
     lines = file_%lines()
 
     l = 1
+#ifndef NAGFOR
     call assert(adjustl(lines(l)%string())=="{", "construct_from_json: expecting '{' to start outermost object", lines(l)%string())
+#endif
 
     l = 2
     metadata = [string_t(""),string_t(""),string_t(""),string_t(""),string_t("false")]

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -124,6 +124,31 @@ contains
     inference_engine%weights_ = weights
     inference_engine%biases_ = biases
     inference_engine%nodes_ = nodes
+
+    block
+      integer i
+
+      if (present(inputs_range)) then
+        inference_engine%inputs_range_ = inputs_range
+      else
+        associate(num_inputs => nodes(lbound(nodes,1)))
+          associate(default_minima => [(0., i=1,num_inputs)], default_maxima => [(1., i=1,num_inputs)])
+            inference_engine%inputs_range_ = tensor_range_t("inputs", default_minima, default_maxima)
+          end associate
+        end associate
+      end if
+
+      if (present(outputs_range)) then
+        inference_engine%outputs_range_ = outputs_range
+      else
+        associate(num_outputs => nodes(ubound(nodes,1)))
+          associate(default_minima => [(0., i=1,num_outputs)], default_maxima => [(1., i=1,num_outputs)])
+            inference_engine%inputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
+          end associate
+        end associate
+      end if
+    end block
+
     call set_activation_strategy(inference_engine)
     call assert_consistency(inference_engine)
 

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -143,7 +143,7 @@ contains
       else
         associate(num_outputs => nodes(ubound(nodes,1)))
           associate(default_minima => [(0., i=1,num_outputs)], default_maxima => [(1., i=1,num_outputs)])
-            inference_engine%inputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
+            inference_engine%outputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
           end associate
         end associate
       end if
@@ -372,6 +372,15 @@ contains
         line = line + 1
         lines(line) = string_t('        "usingSkipConnections": ' // &
                                                        self%metadata_(findloc(key, "usingSkipConnections", dim=1))%string())
+
+        block
+          type(string_t), allocatable :: inputs_range_json(:), outputs_range_json(:)
+          type(file_t) json_file
+          inputs_range_json = self%inputs_range_%to_json() 
+          json_file = file_t(inputs_range_json)
+!          call json_file%write_lines()
+          outputs_range_json = self%outputs_range_%to_json() 
+        end block
 
         line = line + 1
         lines(line) = string_t('    },')

--- a/src/inference_engine/tensor_range_m.f90
+++ b/src/inference_engine/tensor_range_m.f90
@@ -1,3 +1,5 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
 module tensor_range_m
   use tensor_m, only : tensor_t
   use sourcery_m, only : string_t

--- a/src/inference_engine/tensor_range_s.f90
+++ b/src/inference_engine/tensor_range_s.f90
@@ -1,3 +1,5 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
 submodule(tensor_range_m) tensor_range_s
   use assert_m, only : assert
   use sourcery_m, only : separated_values

--- a/src/inference_engine/tensor_range_s.f90
+++ b/src/inference_engine/tensor_range_s.f90
@@ -67,11 +67,17 @@ contains
   end procedure
 
   module procedure map_to_unit_range
-    normalized_tensor = tensor_t((tensor%values() - self%minima_)/(self%maxima_ - self%minima_))
+    associate(tensor_values => tensor%values())
+      normalized_tensor = tensor_t((tensor_values - self%minima_)/(self%maxima_ - self%minima_))
+      call assert(all(tensor_values=>0.).and.all(tensor_values<=1.),"tensor_range_s(map_to_unit_range): normalized output")
+    end associate
   end procedure
 
   module procedure map_from_unit_range
-    unnormalized_tensor = tensor_t(self%minima_ + tensor%values()*(self%maxima_ - self%minima_))
+    associate(tensor_values => tensor%values())
+      call assert(all(tensor_values=>0.).and.all(tensor_values<=1.),"tensor_range_s(map_from_unit_range): normalized input")
+      unnormalized_tensor = tensor_t(self%minima_ + tensor_values)*(self%maxima_ - self%minima_))
+    end associate
   end procedure
 
 end submodule tensor_range_s

--- a/src/inference_engine/tensor_range_s.f90
+++ b/src/inference_engine/tensor_range_s.f90
@@ -68,15 +68,25 @@ contains
 
   module procedure map_to_unit_range
     associate(tensor_values => tensor%values())
-      normalized_tensor = tensor_t((tensor_values - self%minima_)/(self%maxima_ - self%minima_))
-      call assert(all(tensor_values=>0.).and.all(tensor_values<=1.),"tensor_range_s(map_to_unit_range): normalized output")
+      call assert(all(tensor_values>=self%minima_) .and. all(tensor_values<=self%maxima_), &
+        "tensor_range_s(map_to_unit_range): unnormalized range")
+      associate(normalized_values => (tensor_values - self%minima_)/(self%maxima_ - self%minima_))
+        call assert(all(normalized_values>=0.) .and. all(normalized_values<=1.), &
+          "tensor_range_s(map_to_unit_range): normalized range")
+        normalized_tensor = tensor_t(normalized_values)
+      end associate
     end associate
   end procedure
 
   module procedure map_from_unit_range
     associate(tensor_values => tensor%values())
-      call assert(all(tensor_values=>0.).and.all(tensor_values<=1.),"tensor_range_s(map_from_unit_range): normalized input")
-      unnormalized_tensor = tensor_t(self%minima_ + tensor_values)*(self%maxima_ - self%minima_))
+      call assert(all(tensor_values>=0.).and.all(tensor_values<=1.), &
+        "tensor_range_s(map_from_unit_range): normalized input")
+      associate(unnormalized_values => self%minima_ + tensor_values*(self%maxima_ - self%minima_))
+        call assert(all([unnormalized_values>=self%minima_, unnormalized_values<=self%maxima_]), &
+          "tensor_range_s(map_to_unit_range): unnormalized range")
+        unnormalized_tensor = tensor_t(unnormalized_values)
+      end associate
     end associate
   end procedure
 

--- a/src/inference_engine/tensor_range_s.f90
+++ b/src/inference_engine/tensor_range_s.f90
@@ -54,6 +54,9 @@ contains
     character(len=*), parameter :: indent = repeat(" ",ncopies=4)
     character(len=:), allocatable :: csv_format, minima_string, maxima_string
 
+    call assert(allocated(self%layer_), "tensor_range_s(to_json): allocated layer_")
+    call assert(allocated(self%minima_) .and. allocated(self%maxima_), "tensor_range_s(to_json): allocated minima_/maxima_")
+
     csv_format = separated_values(separator=",", mold=[real(rkind)::])
     allocate(character(len=size(self%minima_)*(characters_per_value+1)-1)::minima_string)
     allocate(character(len=size(self%maxima_)*(characters_per_value+1)-1)::maxima_string)

--- a/src/inference_engine/trainable_engine_m.F90
+++ b/src/inference_engine/trainable_engine_m.F90
@@ -18,7 +18,7 @@ module trainable_engine_m
   type trainable_engine_t
     !! Encapsulate the information needed to perform training
     private
-    type(tensor_range_t) inputs_range_, outputs_range_
+    type(tensor_range_t) input_range_, output_range_
     type(string_t), allocatable :: metadata_(:)
     real(rkind), allocatable :: w(:,:,:) ! weights
     real(rkind), allocatable :: b(:,:) ! biases
@@ -39,11 +39,11 @@ module trainable_engine_m
   interface trainable_engine_t
 #ifdef __INTEL_COMPILER
      pure module function construct_trainable_engine_from_padded_arrays( &
-       nodes, weights, biases, differentiable_activation_strategy, metadata, inputs_range, outputs_range &
+       nodes, weights, biases, differentiable_activation_strategy, metadata, input_range, output_range &
      ) &
 #else
      pure module function construct_from_padded_arrays( &
-       nodes, weights, biases, differentiable_activation_strategy, metadata, inputs_range, outputs_range &
+       nodes, weights, biases, differentiable_activation_strategy, metadata, input_range, output_range &
      ) &
 #endif
       result(trainable_engine)
@@ -52,7 +52,7 @@ module trainable_engine_m
       real(rkind), intent(in)  :: weights(:,:,:), biases(:,:)
       class(differentiable_activation_strategy_t), intent(in) :: differentiable_activation_strategy
       type(string_t), intent(in) :: metadata(:)
-      type(tensor_range_t), intent(in), optional :: inputs_range, outputs_range
+      type(tensor_range_t), intent(in), optional :: input_range, output_range
       type(trainable_engine_t) trainable_engine
     end function
 
@@ -62,11 +62,13 @@ module trainable_engine_m
       type(trainable_engine_t) trainable_engine
     end function
 
-    module function perturbed_identity_network(training_configuration, perturbation_magnitude, metadata) result(trainable_engine)
+    module function perturbed_identity_network(training_configuration, perturbation_magnitude, metadata, input_range, output_range)&
+      result(trainable_engine)
       implicit none
       type(training_configuration_t), intent(in) :: training_configuration
       type(string_t), intent(in) :: metadata(:)
       real(rkind), intent(in) :: perturbation_magnitude
+      type(tensor_range_t) input_range, output_range
       type(trainable_engine_t) trainable_engine
     end function
 

--- a/src/inference_engine/trainable_engine_m.F90
+++ b/src/inference_engine/trainable_engine_m.F90
@@ -7,6 +7,7 @@ module trainable_engine_m
   use differentiable_activation_strategy_m, only : differentiable_activation_strategy_t
   use kind_parameters_m, only : rkind
   use tensor_m, only :  tensor_t
+  use tensor_range_m, only :  tensor_range_t
   use mini_batch_m, only : mini_batch_t
   use training_configuration_m, only : training_configuration_t
   implicit none
@@ -17,6 +18,7 @@ module trainable_engine_m
   type trainable_engine_t
     !! Encapsulate the information needed to perform training
     private
+    type(tensor_range_t) inputs_range_, outputs_range_
     type(string_t), allocatable :: metadata_(:)
     real(rkind), allocatable :: w(:,:,:) ! weights
     real(rkind), allocatable :: b(:,:) ! biases
@@ -37,9 +39,12 @@ module trainable_engine_m
   interface trainable_engine_t
 #ifdef __INTEL_COMPILER
      pure module function construct_trainable_engine_from_padded_arrays( &
-       nodes, weights, biases, differentiable_activation_strategy, metadata) &
+       nodes, weights, biases, differentiable_activation_strategy, metadata, inputs_range, outputs_range &
+     ) &
 #else
-     pure module function construct_from_padded_arrays(nodes, weights, biases, differentiable_activation_strategy, metadata) &
+     pure module function construct_from_padded_arrays( &
+       nodes, weights, biases, differentiable_activation_strategy, metadata, inputs_range, outputs_range &
+     ) &
 #endif
       result(trainable_engine)
       implicit none
@@ -47,6 +52,7 @@ module trainable_engine_m
       real(rkind), intent(in)  :: weights(:,:,:), biases(:,:)
       class(differentiable_activation_strategy_t), intent(in) :: differentiable_activation_strategy
       type(string_t), intent(in) :: metadata(:)
+      type(tensor_range_t), intent(in), optional :: inputs_range, outputs_range
       type(trainable_engine_t) trainable_engine
     end function
 

--- a/src/inference_engine/trainable_engine_s.F90
+++ b/src/inference_engine/trainable_engine_s.F90
@@ -249,7 +249,7 @@ contains
       else
         associate(num_outputs => nodes(ubound(nodes,1)))
           associate(default_minima => [(0., i=1,num_outputs)], default_maxima => [(1., i=1,num_outputs)])
-            trainable_engine%inputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
+            trainable_engine%outputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
           end associate
         end associate
       end if
@@ -262,7 +262,7 @@ contains
     ! assignment-stmt disallows the procedure from being pure because it might
     ! deallocate polymorphic allocatable subcomponent `activation_strategy_`
     ! TODO: consider how this affects design
-    inference_engine = inference_engine_t(metadata = self%metadata_, weights = self%w, biases = self%b, nodes = self%n)
+    inference_engine = inference_engine_t(self%metadata_, self%w, self%b, self%n, self%inputs_range_, self%outputs_range_)
   end procedure
 
   module procedure perturbed_identity_network

--- a/src/inference_engine/trainable_engine_s.F90
+++ b/src/inference_engine/trainable_engine_s.F90
@@ -225,13 +225,37 @@ contains
   module procedure construct_from_padded_arrays
 #endif
 
-     trainable_engine%metadata_ = metadata
-     trainable_engine%n = nodes
-     trainable_engine%w = weights
-     trainable_engine%b = biases
-     trainable_engine%differentiable_activation_strategy_ = differentiable_activation_strategy
+    trainable_engine%metadata_ = metadata
+    trainable_engine%n = nodes
+    trainable_engine%w = weights
+    trainable_engine%b = biases
+    trainable_engine%differentiable_activation_strategy_ = differentiable_activation_strategy
 
-     call trainable_engine%assert_consistent
+    block
+      integer i
+
+      if (present(inputs_range)) then
+        trainable_engine%inputs_range_ = inputs_range
+      else
+        associate(num_inputs => nodes(lbound(nodes,1)))
+          associate(default_minima => [(0., i=1,num_inputs)], default_maxima => [(1., i=1,num_inputs)])
+            trainable_engine%inputs_range_ = tensor_range_t("inputs", default_minima, default_maxima)
+          end associate
+        end associate
+      end if
+
+      if (present(outputs_range)) then
+        trainable_engine%outputs_range_ = outputs_range
+      else
+        associate(num_outputs => nodes(ubound(nodes,1)))
+          associate(default_minima => [(0., i=1,num_outputs)], default_maxima => [(1., i=1,num_outputs)])
+            trainable_engine%inputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
+          end associate
+        end associate
+      end if
+    end block
+
+    call trainable_engine%assert_consistent
   end procedure
 
   module procedure to_inference_engine

--- a/src/inference_engine/trainable_engine_s.F90
+++ b/src/inference_engine/trainable_engine_s.F90
@@ -225,32 +225,29 @@ contains
   module procedure construct_from_padded_arrays
 #endif
 
+
     trainable_engine%metadata_ = metadata
     trainable_engine%n = nodes
     trainable_engine%w = weights
     trainable_engine%b = biases
     trainable_engine%differentiable_activation_strategy_ = differentiable_activation_strategy
 
-    block
+    block 
       integer i
 
-      if (present(inputs_range)) then
-        trainable_engine%inputs_range_ = inputs_range
+      if (present(input_range)) then
+         trainable_engine%input_range_ = input_range
       else
         associate(num_inputs => nodes(lbound(nodes,1)))
-          associate(default_minima => [(0., i=1,num_inputs)], default_maxima => [(1., i=1,num_inputs)])
-            trainable_engine%inputs_range_ = tensor_range_t("inputs", default_minima, default_maxima)
-          end associate
+          trainable_engine%input_range_ = tensor_range_t("inputs", minima=[(0., i=1,num_inputs)], maxima=[(1., i=1,num_inputs)])
         end associate
       end if
 
-      if (present(outputs_range)) then
-        trainable_engine%outputs_range_ = outputs_range
+      if (present(output_range)) then
+         trainable_engine%output_range_ = output_range
       else
         associate(num_outputs => nodes(ubound(nodes,1)))
-          associate(default_minima => [(0., i=1,num_outputs)], default_maxima => [(1., i=1,num_outputs)])
-            trainable_engine%outputs_range_ = tensor_range_t("outputs", default_minima, default_maxima)
-          end associate
+          trainable_engine%output_range_ = tensor_range_t("outputs", minima=[(0., i=1,num_outputs)], maxima=[(1., i=1,num_outputs)])
         end associate
       end if
     end block
@@ -262,7 +259,7 @@ contains
     ! assignment-stmt disallows the procedure from being pure because it might
     ! deallocate polymorphic allocatable subcomponent `activation_strategy_`
     ! TODO: consider how this affects design
-    inference_engine = inference_engine_t(self%metadata_, self%w, self%b, self%n, self%inputs_range_, self%outputs_range_)
+    inference_engine = inference_engine_t(self%metadata_, self%w, self%b, self%n, self%input_range_, self%output_range_)
   end procedure
 
   module procedure perturbed_identity_network
@@ -285,7 +282,8 @@ contains
           activation => training_configuration%differentiable_activation_strategy() &
         )
           trainable_engine = trainable_engine_t( &
-            nodes = n, weights = w, biases = b, differentiable_activation_strategy = activation, metadata = metadata &
+            nodes = n, weights = w, biases = b, differentiable_activation_strategy = activation, metadata = metadata, &
+            input_range = input_range, output_range = output_range &
           )
         end associate
       end associate

--- a/test/tensor_range_test_m.f90
+++ b/test/tensor_range_test_m.f90
@@ -67,8 +67,8 @@ contains
     logical test_passes
     real, parameter :: tolerance = 1.E-08
 
-    associate(tensor_range => tensor_range_t(layer="output", minima=[-2., 0., 1., -1.], maxima=[0., 2., 5., 1.]))
-      associate(tensor => tensor_t([-3., 0., 3., 2.]))
+    associate(tensor_range => tensor_range_t(layer="output", minima=[-4., 0., 1., -1.], maxima=[0., 2., 5., 1.]))
+      associate(tensor => tensor_t([-2., 0., 5., 0.]))
         associate(round_trip => tensor_range%map_from_unit_range(tensor_range%map_to_unit_range(tensor)))
           test_passes = all(abs(tensor%values() - round_trip%values()) < tolerance)
         end associate

--- a/test/tensor_range_test_m.f90
+++ b/test/tensor_range_test_m.f90
@@ -39,7 +39,7 @@ contains
       descriptions => &
         [ character(len=len(longest_description)) :: &
           "component-wise construction followed by conversion to and from JSON", &
-          "mapping to and from the unit interval is an identity transformation" &
+          "mapping to and from the unit interval as an identity transformation" &
         ], &
       outcomes => &
         [ write_then_read_tensor_range(), & 


### PR DESCRIPTION
This PR facilitates storing the range of values encountered in the training data for purposes of

1. Preventing undesired extrapolation during inference and
2. Normalizing inputs and unnormalizing outputs during inference to match the practice used in training.

See the cloud-microphysics subdirectory for an example of mechanics and utility of training-data normalization to aid convergence.
    
**BREAKING CHANGE:** network files will now contain a tensor_range JSON objects for inputs followed by a tensor_range JSON object for outputs, each of which stores a string label ("inputs" for the first and "outputs" for the second) followed by "minima" arrays and "maxima" arrays.