### PR TITLE
Work around ifx automatic-offloading bugs

### DIFF
--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -308,11 +308,26 @@ contains
       difference%nodes_difference_(l)  = self%nodes_(l) - rhs%nodes_(l)
      
       associate(n => self%nodes_)
+#ifndef __INTEL_COMPILER
         do concurrent(l = 1:ubound(n,1))
           difference%weights_difference_(1:n(l),1:n(l-1),l) = self%weights_(1:n(l),1:n(l-1),l) - rhs%weights_(1:n(l),1:n(l-1),l)
           difference%biases_difference_(1:n(l),l) = self%biases_(1:n(l),l) - rhs%biases_(1:n(l),l)
           difference%nodes_difference_(l) = self%nodes_(l) - rhs%nodes_(l)
         end do
+#else
+        block
+          integer j, k
+          do l = 1, ubound(n,1)
+            do j = 1, n(l)
+              do k = 1, n(l-1)
+                difference%weights_difference_(j,k,l) = self%weights_(j,k,l) - rhs%weights_(j,k,l)
+                difference%biases_difference_(j,l) = self%biases_(j,l) - rhs%biases_(j,l)
+                difference%nodes_difference_(l) = self%nodes_(l) - rhs%nodes_(l)
+              end do
+            end do
+          end do
+        end block
+#endif
       end associate
 
     end block

--- a/test/trainable_engine_test_m.F90
+++ b/test/trainable_engine_test_m.F90
@@ -286,7 +286,7 @@ contains
       !! Depending on where in the random-number sequence the weights start, this test can pass for lower
       !! numbers of iterations, e.g., 400000. Using more iterations gives more robust convergence.
 #else
-    integer, parameter :: num_inputs=2, mini_batch_size = 1, num_iterations=52219
+    integer, parameter :: num_inputs=2, mini_batch_size = 1, num_iterations=49000
       !! Reducing num_iterations yields a less robust test, but increasing num_iterations causes this
       !! test to crash when compiled with the Intel ifx compiler.
 #endif


### PR DESCRIPTION
This PR works around issues that arise when the following build command is used to tell the `ifx` compiler to automatically offload `do concurrent` constructs to a GPU:
```
fpm test --compiler ifx --flag "-coarray -coarray-num-images=1 -fopenmp-target-do-concurrent -qopenmp -fopenmp-targets=spir64"
```
The workarounds are
1. further reduce iterations in `trainable_engine_test_m` so training converges with `ifx` without crashing
2. convert `do concurrent` with array statements to `do` loops