### PR TITLE
Feature: redesigned functionality for mapping input and output tensors to and from training ranges

### DIFF
--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -31,8 +31,8 @@ module inference_engine_m_
   contains
     procedure :: infer
     procedure :: to_json
-    procedure :: input_range
-    procedure :: output_range
+    procedure :: map_to_input_range
+    procedure :: map_from_output_range
     procedure :: num_inputs
     procedure :: num_outputs
     procedure :: nodes_per_layer
@@ -82,16 +82,18 @@ module inference_engine_m_
 
   interface
 
-    pure module function input_range(self) result(my_input_range)
+    pure module function map_to_input_range(self, tensor) result(normalized_tensor)
       implicit none
       class(inference_engine_t), intent(in) :: self
-      type(tensor_range_t) my_input_range
+      type(tensor_t), intent(in) :: tensor
+      type(tensor_t) normalized_tensor
     end function
 
-    pure module function output_range(self) result(my_output_range)
+    pure module function map_from_output_range(self, normalized_tensor) result(tensor)
       implicit none
       class(inference_engine_t), intent(in) :: self
-      type(tensor_range_t) my_output_range
+      type(tensor_t), intent(in) :: normalized_tensor
+      type(tensor_t) tensor
     end function
 
     pure module function to_exchange(self) result(exchange)

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -82,14 +82,16 @@ module inference_engine_m_
 
   interface
 
-    pure module function map_to_input_range(self, tensor) result(normalized_tensor)
+    elemental module function map_to_input_range(self, tensor) result(normalized_tensor)
+      !! The result contains the input tensor values normalized to fall on the range used during training
       implicit none
       class(inference_engine_t), intent(in) :: self
       type(tensor_t), intent(in) :: tensor
       type(tensor_t) normalized_tensor
     end function
 
-    pure module function map_from_output_range(self, normalized_tensor) result(tensor)
+    elemental module function map_from_output_range(self, normalized_tensor) result(tensor)
+      !! The result contains the output tensor values unnormalized via the inverse of the mapping used in training
       implicit none
       class(inference_engine_t), intent(in) :: self
       type(tensor_t), intent(in) :: normalized_tensor

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -18,12 +18,12 @@ submodule(inference_engine_m_) inference_engine_s
 
 contains
 
-  module procedure input_range
-    my_input_range = self%input_range_
+  module procedure map_to_input_range
+    normalized_tensor = self%input_range_%map_to_training_range(tensor)
   end procedure
 
-  module procedure output_range
-    my_output_range = self%output_range_
+  module procedure map_from_output_range
+    tensor = self%output_range_%map_from_training_range(normalized_tensor)
   end procedure
 
   module procedure to_exchange


### PR DESCRIPTION
Breaking Change
-----------------
This commit replaces pull request #147's `inference_engine_t` `input_range` and `output_range` getters with tensor mapping functions that delegate the input and output tensor mappings to the corresponding `inference_engine_t` `input_range_` and `output_range_` components' own `map_to_training_range` and `map_from_training_range` type-bound functions.