### PR TITLE
build: update to sourcery 4.8.1

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -6,4 +6,4 @@ maintainer = "rouson@lbl.gov"
 
 [dependencies]
 assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.6.0"}
-sourcery = {git = "https://github.com/sourceryinstitute/sourcery", tag = "4.8.0"}
+sourcery = {git = "https://github.com/sourceryinstitute/sourcery", tag = "4.8.1"}


### PR DESCRIPTION
This ensures that the latest changes in the Sourcery dependency can be built by the ifx compiler.