### PR TITLE
Add bug workarounds for gfortran-14 associate-stmt bug

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,17 +8,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest]
+        os: [macOS-12]
       fail-fast: true
     env:
       FC: gfortran
-      GCC_V: 13
+      GCC_V: 14
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
 
     - name: Install Dependencies MacOS
+      if: contains(matrix.os, 'mac')
       run: |
         brew install gcc@${GCC_V}
         sudo ln -s $(which gfortran-${GCC_V}) $(dirname $(which gfortran-${GCC_V}))/gfortran

--- a/example/learn-addition.F90
+++ b/example/learn-addition.F90
@@ -84,7 +84,7 @@ program learn_addition
       block
         real, parameter :: tolerance = 1.E-06
         integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
@@ -94,7 +94,8 @@ program learn_addition
           do p = 1, num_pairs
             print "(6G13.5, a1, 6G13.5)",network_outputs(p)%values(),       "|", desired_outputs(p)%values()
           end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block

--- a/example/learn-exponentiation.F90
+++ b/example/learn-exponentiation.F90
@@ -84,7 +84,7 @@ program learn_exponentiation
       block
         real, parameter :: tolerance = 1.E-06
         integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
@@ -94,7 +94,8 @@ program learn_exponentiation
           do p = 1, num_pairs
             print "(6G13.5, a1, 6G13.5)",network_outputs(p)%values(),       "|", desired_outputs(p)%values()
           end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block

--- a/example/learn-microphysics-procedures.F90
+++ b/example/learn-microphysics-procedures.F90
@@ -120,7 +120,7 @@ program learn_microphysics_procedures
         report_network_performance: &
         block
           integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
           type(tensor_t), allocatable :: network_outputs(:)
           network_outputs = trainable_engine%infer(inputs)
 #else
@@ -130,7 +130,8 @@ program learn_microphysics_procedures
             do p = 1, num_pairs
               print "(6(G13.5,2x))", inputs(p)%values(), network_outputs(p)%values(), desired_outputs(p)%values()
             end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
           end associate
 #endif
         end block report_network_performance

--- a/example/learn-multiplication.F90
+++ b/example/learn-multiplication.F90
@@ -84,7 +84,7 @@ program learn_multiplication
       block
         real, parameter :: tolerance = 1.E-06
         integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
@@ -94,7 +94,8 @@ program learn_multiplication
           do p = 1, num_pairs
             print "(6G13.5, a1, 6G13.5)",network_outputs(p)%values(),       "|", desired_outputs(p)%values()
           end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block

--- a/example/learn-power-series.F90
+++ b/example/learn-power-series.F90
@@ -86,7 +86,7 @@ program learn_power_series
       block
         real, parameter :: tolerance = 1.E-06
         integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
@@ -96,7 +96,8 @@ program learn_power_series
           do p = 1, num_pairs
             print "(6G13.5, a1, 6G13.5)",network_outputs(p)%values(),       "|", desired_outputs(p)%values()
           end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block

--- a/example/learn-saturated-mixing-ratio.F90
+++ b/example/learn-saturated-mixing-ratio.F90
@@ -119,7 +119,7 @@ program train_saturated_mixture_ratio
         report_network_performance: &
         block
           integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
           type(tensor_t), allocatable :: network_outputs(:)
           network_outputs = trainable_engine%infer(inputs)
 #else
@@ -129,7 +129,8 @@ program train_saturated_mixture_ratio
             do p = 1, num_pairs
               print "(4(G13.5,2x))", inputs(p)%values(), network_outputs(p)%values(), desired_outputs(p)%values()
             end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
           end associate
 #endif
         end block report_network_performance

--- a/example/train-and-write.F90
+++ b/example/train-and-write.F90
@@ -72,7 +72,7 @@ program train_and_write
       block
         real, parameter :: tolerance = 1.E-06
         integer p
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
@@ -84,7 +84,8 @@ program train_and_write
           do p = 1, num_pairs
             print *,network_outputs(p)%values(),"|", inputs(p)%values(), "|",  network_outputs(p)%values() - inputs(p)%values()
           end do
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block

--- a/fpm.toml
+++ b/fpm.toml
@@ -6,4 +6,4 @@ maintainer = "rouson@lbl.gov"
 
 [dependencies]
 assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.7.0"}
-julienne = {git = "https://github.com/sourceryinstitute/julienne", tag = "442819a6c11a055c94cc29e1f78d935c9736abb5"}
+julienne = {git = "https://github.com/sourceryinstitute/julienne", tag = "2ca5c93e11b46395608fd00abbdf797d9be0b3d4"}

--- a/setup.sh
+++ b/setup.sh
@@ -74,8 +74,8 @@ if ! command -v fpm > /dev/null ; then
   fi
 fi
 
-FPM_FC=${FC:-"gfortran-13"}
-FPM_CC=${CC:-"gcc-13"}
+FPM_FC=${FC:-"gfortran-14"}
+FPM_CC=${CC:-"gcc-14"}
 
 fpm test --profile release --flag "-fopenmp"
 

--- a/test/trainable_engine_test_m.F90
+++ b/test/trainable_engine_test_m.F90
@@ -466,14 +466,15 @@ contains
 
       block
         real(rkind), parameter :: tolerance = 1.E-06
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
         associate(network_outputs => trainable_engine%infer(inputs))
 #endif
           test_passes = maxval(abs([(network_outputs(i)%values() - inputs(i)%values(), i=1,num_pairs)])) < tolerance
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block
@@ -527,14 +528,15 @@ contains
 
       block
         real(rkind), parameter :: tolerance = 1.E-06
-#ifdef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
         type(tensor_t), allocatable :: network_outputs(:)
         network_outputs = trainable_engine%infer(inputs)
 #else
         associate(network_outputs => trainable_engine%infer(inputs))
 #endif
           test_passes = maxval(abs([(network_outputs(i)%values() - inputs(i)%values(), i=1,num_pairs)])) < tolerance
-#ifndef _CRAYFTN
+#if defined _CRAYFTN || __GFORTRAN__
+#else
         end associate
 #endif
       end block


### PR DESCRIPTION
This branch adds fixes to the branch `switch-to-julienne` that allow the project to compile and test successfully. Once this is merged into the `switch-to-julienne` branch, that branch can be reviewed as a PR and merged into main.

The main changes are adding bug workarounds for an associate-stmt bug that was reintroduced into `gfortran-14`