### PR TITLE
Support compilation with LLVM Flang

### DIFF
--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -62,7 +62,7 @@ module inference_engine_m_
 
   interface inference_engine_t
 
-    pure module function construct_from_padded_arrays(metadata, weights, biases, nodes, input_range, output_range) &
+    impure module function construct_from_padded_arrays(metadata, weights, biases, nodes, input_range, output_range) &
       result(inference_engine)
       implicit none
       type(string_t), intent(in) :: metadata(:)
@@ -98,7 +98,7 @@ module inference_engine_m_
       type(tensor_t) tensor
     end function
 
-    pure module function to_exchange(self) result(exchange)
+    impure module function to_exchange(self) result(exchange)
       implicit none
       class(inference_engine_t), intent(in) :: self
       type(exchange_t) exchange

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -128,13 +128,9 @@ contains
 
   end subroutine
 
-  pure subroutine set_activation_strategy(inference_engine)
+  impure subroutine set_activation_strategy(inference_engine)
     type(inference_engine_t), intent(inout) :: inference_engine
     character(len=:), allocatable :: function_name
-    ! This code is called in both constructors and and can't be refactored into a factory method
-    ! pattern because the result would need to be allocatable and polymorphic, which would preclude
-    ! the function being pure so it wouldn't be possible to call it from inside the pure constructor
-    ! functions.
     function_name = inference_engine%metadata_(findloc(key, "activationFunction", dim=1))%string()
     select case(function_name)
       case("swish")

--- a/src/inference_engine/trainable_engine_m.F90
+++ b/src/inference_engine/trainable_engine_m.F90
@@ -42,11 +42,11 @@ module trainable_engine_m
 
   interface trainable_engine_t
 #ifdef __INTEL_COMPILER
-     pure module function construct_trainable_engine_from_padded_arrays( &
+     impure module function construct_trainable_engine_from_padded_arrays( &
        nodes, weights, biases, differentiable_activation_strategy, metadata, input_range, output_range &
      ) &
 #else
-     pure module function construct_from_padded_arrays( &
+     impure module function construct_from_padded_arrays( &
        nodes, weights, biases, differentiable_activation_strategy, metadata, input_range, output_range &
      ) &
 #endif
@@ -60,7 +60,7 @@ module trainable_engine_m
       type(trainable_engine_t) trainable_engine
     end function
 
-    pure module function construct_from_inference_engine(inference_engine) result(trainable_engine)
+    impure module function construct_from_inference_engine(inference_engine) result(trainable_engine)
       implicit none
       type(inference_engine_t), intent(in) :: inference_engine
       type(trainable_engine_t) trainable_engine

--- a/test/main.F90
+++ b/test/main.F90
@@ -50,7 +50,9 @@ program main
   print *,"Test suite execution time: ",t_finish - t_start
   print *
   print '(*(a,:,g0))',"_________ In total, ",passes," of ",tests, " tests pass. _________"
+#ifndef __flang__
   sync all
+#endif
   print *
   if (passes/=tests) error stop "-------- One or more tests failed. See the above report. ---------"
 end program


### PR DESCRIPTION
### Changes on branch
- Fix bug unveiled by LLVM flang by replacing `pure` with `impure` keyword in procedures with an assignment-stmt or a result that involves polymorphic allocatable components.
- Add macro for flang to avoid compiling a `sync-all-stmt`.