### PR TITLE
Update cloud-microphysics compiler and dependencies

### DIFF
--- a/cloud-microphysics/app/tensor-statistics.f90
+++ b/cloud-microphysics/app/tensor-statistics.f90
@@ -7,7 +7,7 @@ program tensor_statistics
   !! 2. Saves the resulting statistics to text files with space-separated columns and column labels.
 
   ! External dependencies:
-  use sourcery_m, only : command_line_t, file_t, string_t
+  use julienne_m, only : command_line_t, file_t, string_t
   use assert_m, only : assert, intrinsic_array_t
   use inference_engine_m, only : rkind, ubounds_t
   use ieee_arithmetic, only : ieee_is_nan

--- a/cloud-microphysics/app/train-cloud-microphysics.f90
+++ b/cloud-microphysics/app/train-cloud-microphysics.f90
@@ -10,7 +10,7 @@ program train_cloud_microphysics
   !! https://github.com/BerkeleyLab/icar.
 
   !! External dependencies:
-  use sourcery_m, only : string_t, file_t, command_line_t, bin_t
+  use julienne_m, only : string_t, file_t, command_line_t, bin_t
   use assert_m, only : assert, intrinsic_array_t
   use tensor_range_m, only : tensor_range_t
   use ieee_arithmetic, only : ieee_is_nan

--- a/cloud-microphysics/fpm.toml
+++ b/cloud-microphysics/fpm.toml
@@ -5,7 +5,7 @@ author = "Damian Rouson, Tan Nguyen, Jordan Welsman, David Torres, Brad Richards
 maintainer = "rouson@lbl.gov"
 
 [dependencies]
-assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.6.0"}
-sourcery = {git = "https://github.com/sourceryinstitute/sourcery", tag = "4.6.1"}
+assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.7.0"}
+julienne = {git = "https://github.com/sourceryinstitute/julienne", tag = "1.0.0"}
 inference-engine = {path = "../"}
 netcdf-interfaces = {git = "https://github.com/LKedward/netcdf-interfaces.git", rev = "d2bbb71ac52b4e346b62572b1ca1620134481096"}

--- a/cloud-microphysics/setup.sh
+++ b/cloud-microphysics/setup.sh
@@ -54,8 +54,7 @@ if ! command -v brew > /dev/null ; then
   fi
 fi
 
-brew tap fortran-lang/fortran # required for building fpm
-brew install fortran-lang/fortran/fpm netcdf netcdf-fortran pkg-config coreutils # coreutils supports `realpath` below
+brew install netcdf netcdf-fortran pkg-config coreutils # coreutils supports `realpath` below
 
 PREFIX=`realpath $PREFIX`
 
@@ -65,8 +64,8 @@ NETCDFF_LIB_PATH="`brew --prefix netcdf-fortran`/lib"
 
 FPM_LD_FLAG=" -L$NETCDF_LIB_PATH -L$HDF5_LIB_PATH -L$NETCDFF_LIB_PATH"
 FPM_FLAG="-fcoarray=single -O3 -fallow-argument-mismatch -ffree-line-length-none -L$NETCDF_LIB_PATH -L$HDF5_LIB_PATH"
-FPM_FC=${FC:-"gfortran-13"}
-FPM_CC=${CC:-"gcc-13"}
+FPM_FC=${FC:-"gfortran-14"}
+FPM_CC=${CC:-"gcc-14"}
 
 mkdir -p build
 

--- a/cloud-microphysics/src/histogram_m.f90
+++ b/cloud-microphysics/src/histogram_m.f90
@@ -2,7 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 module histogram_m
   !! Generate and represent histograms
-  use sourcery_m, only : file_t
+  use julienne_m, only : file_t
   implicit none
 
   private

--- a/cloud-microphysics/src/histogram_s.f90
+++ b/cloud-microphysics/src/histogram_s.f90
@@ -3,7 +3,7 @@
 submodule(histogram_m) histogram_s
   use assert_m, only : assert, intrinsic_array_t
   use kind_parameters_m, only : rkind
-  use sourcery_m, only : string_t, operator(.cat.)
+  use julienne_m, only : string_t, operator(.cat.)
   implicit none
 
 contains

--- a/cloud-microphysics/test/netCDF_file_test_m.f90
+++ b/cloud-microphysics/test/netCDF_file_test_m.f90
@@ -8,7 +8,7 @@ module NetCDF_file_test_m
 
   ! External dependencies
   use assert_m, only : assert
-  use sourcery_m, only : string_t, test_t, test_result_t
+  use julienne_m, only : string_t, test_t, test_result_t
   use netcdf, only : &
      nf90_create, nf90_def_dim, nf90_def_var, nf90_enddef, nf90_put_var, nf90_inquire_dimension, & ! functions
      nf90_close, nf90_open, nf90_inq_varid, nf90_get_var, nf90_inquire_variable, &


### PR DESCRIPTION
Switching the rest of Inference-Engine from depending on Sourcery to depending on Julienne broke the building of the `fpm` project in the `cloud-microphysics/` subdirectory.  This PR

1. Switches `cloud-microphysics/` from Sourcery to Julienne,
2. Updates the GCC compilers in `setup.sh` from version 13 to the latest version: 14, and
3. Updates the Assert dependency from version 1.6.0 to the latest version: 1.7.0.

where item 1 fixes the aforementioned build problem.