### PR TITLE
Read & perform inference on networks for which the hidden-layer width varies across layers

### DIFF
--- a/example/read-query-infer.f90
+++ b/example/read-query-infer.f90
@@ -1,0 +1,56 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+program read_query_infer
+  !! This program demonstrates how to read a neural network from a JSON file,
+  !! query the network object for some of its properties, print those properties,
+  !! and use the network to perform inference.  
+  use inference_engine_m, only : inference_engine_t, relu_t, tensor_t
+  use julienne_m, only : string_t, command_line_t, file_t
+  use kind_parameters_m, only : rkind
+  implicit none
+
+  type(command_line_t) command_line
+  type(inference_engine_t) inference_engine
+
+  associate(file_name => string_t(command_line%flag_value("--input-file")))
+
+    if (len(file_name%string())==0) then
+      error stop new_line('a') // new_line('a') // &
+        'Usage: fpm run --example read-query -- --input-file "<file-name>"' 
+    end if
+
+    print *, "Reading an inference_engine_t object from the same JSON file '"//file_name%string()//"'."
+    associate(inference_engine => inference_engine_t(file_t(file_name)))
+
+      print *, "Querying the new inference_engine_t object for several properties:"
+      associate(activation_name => inference_engine%activation_function_name())
+        print *, "Activation function: ", activation_name%string()
+      end associate
+      print *, "Number of outputs:", inference_engine%num_outputs()
+      print *, "Number of inputs:", inference_engine%num_inputs()
+      print *, "Nodes per layer:", inference_engine%nodes_per_layer()
+      print *, "Performing inference:"
+
+      block
+        integer, parameter :: tensor_size = 2, num_tests = 3
+        real, parameter :: tensor_range = 11.
+        real harvest(tensor_size)
+        integer i
+
+        call random_init(repeatable=.false., image_distinct=.true.)
+
+        print *, "Inputs                 |       Outputs  "
+
+        do i = 1, num_tests
+          call random_number(harvest)
+          associate(inputs => tensor_t(tensor_range*harvest))
+            associate(outputs => inference_engine%infer(inputs))
+              print '(2(2g12.5,a,2x))', inputs%values(), "|",  outputs%values()
+            end associate
+          end associate
+        end do
+
+      end block
+    end associate ! associate(inference_engine => ...)
+  end associate ! associate(file_name => ...)
+end program

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -6,6 +6,7 @@ module inference_engine_m_
   use julienne_file_m, only : file_t
   use julienne_string_m, only : string_t
   use kind_parameters_m, only : rkind
+  use metadata_m, only : metadata_t
   use tensor_m, only : tensor_t
   use tensor_range_m, only : tensor_range_t
   use differentiable_activation_strategy_m, only :differentiable_activation_strategy_t
@@ -47,6 +48,7 @@ module inference_engine_m_
   type exchange_t
     type(tensor_range_t) input_range_, output_range_
     type(string_t) metadata_(size(key))
+    type(metadata_t) metadata_object
     real(rkind), allocatable :: weights_(:,:,:), biases_(:,:)
     integer, allocatable :: nodes_(:)
     class(activation_strategy_t), allocatable :: activation_strategy_ ! Strategy Pattern facilitates elemental activation

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -25,7 +25,7 @@ module inference_engine_m_
     !! Encapsulate the minimal information needed to perform inference
     private
     type(tensor_range_t) input_range_, output_range_
-    type(string_t) metadata_(size(key))
+    type(metadata_t) metadata_
     real(rkind), allocatable :: weights_(:,:,:), biases_(:,:)
     integer, allocatable :: nodes_(:)
     class(activation_strategy_t), allocatable :: activation_strategy_ ! Strategy Pattern facilitates elemental activation

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -73,7 +73,7 @@ module inference_engine_m_
       type(inference_engine_t) inference_engine
     end function
 
-    impure elemental module function construct_from_json(file_) result(inference_engine)
+    impure elemental module function from_json(file_) result(inference_engine)
       implicit none
       type(file_t), intent(in) :: file_
       type(inference_engine_t) inference_engine

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -47,8 +47,7 @@ module inference_engine_m_
 
   type exchange_t
     type(tensor_range_t) input_range_, output_range_
-    type(string_t) metadata_(size(key))
-    type(metadata_t) metadata_object
+    type(metadata_t) metadata_
     real(rkind), allocatable :: weights_(:,:,:), biases_(:,:)
     integer, allocatable :: nodes_(:)
     class(activation_strategy_t), allocatable :: activation_strategy_ ! Strategy Pattern facilitates elemental activation

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -199,9 +199,7 @@ contains
     lines = file_%lines()
 
     l = 1
-#ifndef NAGFOR
     call assert(adjustl(lines(l)%string())=="{", "construct_from_json: expecting '{' to start outermost object", lines(l)%string())
-#endif
 
     l = 9
     call assert(adjustl(lines(l)%string())=='"tensor_range": {', 'from_json: expecting "tensor_range": {', lines(l)%string())

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -195,13 +195,13 @@ contains
     type(string_t), allocatable :: lines(:), metadata(:)
     type(tensor_range_t) input_range, output_range
     type(layer_t) hidden_layers, output_layer
-    type(neuron_t) output_neuron
     real(rkind), allocatable :: hidden_weights(:,:,:)
     character(len=:), allocatable :: justified_line
     integer l
 #ifdef _CRAYFTN
     type(tensor_range_t) proto_range
     type(metadata_t) proto_meta
+    type(neuron_t) proto_neuron
     proto_range = tensor_range_t("",[0.],[1.])
     proto_meta = metadata_t(string_t(""),string_t(""),string_t(""),string_t(""),string_t(""))
 #endif
@@ -476,9 +476,9 @@ contains
             line = line + num_tensor_range_lines
 
             lines(line) = string_t('     "hidden_layers": [')
+            line = line + 1
 
             layer = 1 
-            line = line + 1
             lines(line) = string_t('         [')
             do neuron = 1, neurons_per_layer
               line = line + 1

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -31,6 +31,7 @@ contains
     exchange%input_range_ = self%input_range_
     exchange%output_range_ = self%output_range_
     exchange%metadata_ = self%metadata_
+    exchange%metadata_object = metadata_t(self%metadata_(1),self%metadata_(2),self%metadata_(3),self%metadata_(4),self%metadata_(5))
     exchange%weights_ = self%weights_
     exchange%biases_ = self%biases_
     exchange%nodes_ = self%nodes_

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -422,30 +422,18 @@ contains
       )
         allocate(lines(num_lines))
 
-        line = 1
-        lines(line) = string_t('{')
+        lines(1:8) = &
+          [ string_t('{') &
+           ,string_t('    "metadata": {') &
+           ,string_t('        "modelName": "' // self%metadata_(findloc(key, "modelName", dim=1))%string() // '",') &
+           ,string_t('        "modelAuthor": "' // self%metadata_(findloc(key, "modelAuthor", dim=1))%string() // '",') &
+           ,string_t('        "compilationDate": "' // self%metadata_(findloc(key, "compilationDate", dim=1))%string() // '",') &
+           ,string_t('        "activationFunction": "'//self%metadata_(findloc(key, "activationFunction", dim=1))%string() // '",')&
+           ,string_t('        "usingSkipConnections": ' // self%metadata_(findloc(key, "usingSkipConnections", dim=1))%string()) &
+           ,string_t('    },') &
+          ]
 
-        line = line + 1
-        lines(line) = string_t('    "metadata": {')
-
-        line = line + 1
-        lines(line) = string_t('        "modelName": "' // &
-                                                       self%metadata_(findloc(key, "modelName", dim=1))%string() // '",')
-        line = line + 1
-        lines(line) = string_t('        "modelAuthor": "' // &
-                                                       self%metadata_(findloc(key, "modelAuthor", dim=1))%string() // '",')
-        line = line + 1
-        lines(line) = string_t('        "compilationDate": "' // &
-                                                       self%metadata_(findloc(key, "compilationDate", dim=1))%string() // '",')
-        line = line + 1
-        lines(line) = string_t('        "activationFunction": "' // &
-                                                       self%metadata_(findloc(key, "activationFunction", dim=1))%string() // '",')
-        line = line + 1
-        lines(line) = string_t('        "usingSkipConnections": ' // &
-                                                       self%metadata_(findloc(key, "usingSkipConnections", dim=1))%string())
-
-        line = line + 1
-        lines(line) = string_t('    },')
+        line = 8
 
         block
           type(string_t), allocatable :: input_range_json(:), output_range_json(:)

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -30,8 +30,7 @@ contains
   module procedure to_exchange
     exchange%input_range_ = self%input_range_
     exchange%output_range_ = self%output_range_
-    exchange%metadata_ = self%metadata_
-    exchange%metadata_object = metadata_t(self%metadata_(1),self%metadata_(2),self%metadata_(3),self%metadata_(4),self%metadata_(5))
+    exchange%metadata_ = metadata_t(self%metadata_(1),self%metadata_(2),self%metadata_(3),self%metadata_(4),self%metadata_(5))
     exchange%weights_ = self%weights_
     exchange%biases_ = self%biases_
     exchange%nodes_ = self%nodes_

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -131,25 +131,25 @@ contains
 
   end subroutine
 
-  impure subroutine set_activation_strategy(inference_engine)
-    type(inference_engine_t), intent(inout) :: inference_engine
-    associate(strings => inference_engine%metadata_%strings())
-      select case(strings(4)%string())
-        case("swish")
-          inference_engine%activation_strategy_ = swish_t()
-        case("sigmoid")
-          inference_engine%activation_strategy_ = sigmoid_t()
-        case("step")
-          inference_engine%activation_strategy_ = step_t()
-        case("gelu")
-          inference_engine%activation_strategy_ = gelu_t()
-        case("relu")
-          inference_engine%activation_strategy_ = relu_t()
-        case default
-          error stop "inference_engine_s(set_activation_strategy): unrecognized activation strategy '"//strings(4)%string()//"'"
-      end select
-    end associate
-  end subroutine
+  impure function activation_factory(activation_name) result(activation)
+    character(len=*), intent(in) :: activation_name
+    class(activation_strategy_t), allocatable :: activation
+
+    select case(activation_name)
+      case("swish")
+        activation = swish_t()
+      case("sigmoid")
+        activation = sigmoid_t()
+      case("step")
+        activation = step_t()
+      case("gelu")
+        activation = gelu_t()
+      case("relu")
+        activation = relu_t()
+      case default
+        error stop "inference_engine_s(activation_factory): unrecognized activation strategy '"//activation_name//"'"
+    end select
+  end function
 
   module procedure construct_from_padded_arrays
 
@@ -182,7 +182,10 @@ contains
       end if
     end block
 
-    call set_activation_strategy(inference_engine)
+    associate(strings => inference_engine%metadata_%strings())
+      inference_engine%activation_strategy_ = activation_factory(strings(4)%string())
+    end associate
+
     call assert_consistency(inference_engine)
 
   end procedure construct_from_padded_arrays
@@ -277,7 +280,10 @@ contains
 #endif
     end associate
 
-    call set_activation_strategy(inference_engine)
+    associate(strings => inference_engine%metadata_%strings())
+      inference_engine%activation_strategy_ = activation_factory(strings(4)%string())
+    end associate
+
     call assert_consistency(inference_engine)
 
   contains

--- a/src/inference_engine/metadata_m.f90
+++ b/src/inference_engine/metadata_m.f90
@@ -9,6 +9,7 @@ module metadata_m
     private
     type(string_t) modelName_, modelAuthor_, compilationDate_, activationFunction_, usingSkipConnections_
   contains
+    procedure :: strings
     procedure :: to_json
     procedure :: equals
     generic :: operator(==) => equals
@@ -32,6 +33,12 @@ module metadata_m
   end interface
 
   interface
+
+    pure module function strings(self) result(components)
+      implicit none
+      class(metadata_t), intent(in) :: self
+      type(string_t), allocatable :: components(:)
+    end function
 
     pure module function to_json(self) result(lines)
       implicit none

--- a/src/inference_engine/metadata_m.f90
+++ b/src/inference_engine/metadata_m.f90
@@ -1,0 +1,50 @@
+module metadata_m
+  use julienne_string_m, only : string_t
+  implicit none
+
+  private
+  public :: metadata_t
+
+  type metadata_t
+    private
+    type(string_t) modelName_, modelAuthor_, compilationDate_, activationFunction_, usingSkipConnections_
+  contains
+    procedure :: to_json
+    procedure :: equals
+    generic :: operator(==) => equals
+  end type
+
+  interface metadata_t
+
+    pure module function from_json(lines) result(metadata)
+      implicit none
+      type(string_t), intent(in) :: lines(:)
+      type(metadata_t) metadata
+    end function
+
+    pure module function from_components(modelName, modelAuthor, compilationDate, activationFunction, usingSkipConnections) &
+      result(metadata)
+      implicit none
+      type(string_t), intent(in) :: modelName, modelAuthor, compilationDate, activationFunction, usingSkipConnections
+      type(metadata_t) metadata
+    end function
+
+  end interface
+
+  interface
+
+    pure module function to_json(self) result(lines)
+      implicit none
+      class(metadata_t), intent(in) :: self
+      type(string_t), allocatable :: lines(:)
+    end function
+
+    elemental module function equals(lhs, rhs) result(lhs_equals_rhs)
+      implicit none
+      class(metadata_t), intent(in) :: lhs, rhs
+      logical lhs_equals_rhs
+    end function
+
+  end interface
+
+end module

--- a/src/inference_engine/metadata_s.f90
+++ b/src/inference_engine/metadata_s.f90
@@ -1,0 +1,66 @@
+submodule(metadata_m) metadata_s
+  use assert_m, only : assert
+  implicit none
+
+contains
+
+  module procedure from_components
+    metadata%modelName_ = modelName
+    metadata%modelAuthor_ = modelAuthor
+    metadata%compilationDate_ = compilationDate
+    metadata%activationFunction_ = activationFunction
+    metadata%usingSkipConnections_ = usingSkipConnections
+  end procedure 
+
+  module procedure from_json
+    integer l
+
+    call assert(lines(1)%get_json_key() == "metadata", "metadata_s(from_json): metadata found")
+
+    do l = 2, size(lines)-1
+      associate(key => lines(l)%get_json_key())
+        select case (key%string())
+          case("modelName")
+            metadata%modelName_ = lines(l)%get_json_value(key, mold=string_t(""))
+          case("modelAuthor")
+            metadata%modelAuthor_ = lines(l)%get_json_value(key, mold=string_t(""))
+          case("compilationDate")
+            metadata%compilationDate_ = lines(l)%get_json_value(key, mold=string_t(""))
+          case("activationFunction")
+            metadata%activationFunction_ = lines(l)%get_json_value(key, mold=string_t(""))
+          case("usingSkipConnections")
+            metadata%usingSkipConnections_ = lines(l)%get_json_value(key, mold=string_t(""))
+          case default
+            error stop "metadata_s(from_json): missing key " // key%string()
+        end select
+      end associate
+    end do
+
+    call assert(trim(adjustl(lines(size(lines))%string())) == "}," , "metadata_s(from_json): metadata object end found")
+  end procedure
+
+  module procedure to_json
+
+    character(len=*), parameter :: indent = repeat(" ",ncopies=4)
+
+    lines = [ &
+      string_t(indent // '"metadata": {'), &
+      string_t(indent // indent // '"modelName" : "'  // trim(adjustl(self%modelName_%string()))  // '"' ), &
+      string_t(indent // indent // '"modelAuthor" : "'  // trim(adjustl(self%modelAuthor_%string())) // '"' ), &
+      string_t(indent // indent // '"compilationDate" : "' // trim(adjustl(self%compilationDate_%string())) // '"'), &
+      string_t(indent // indent // '"activationFunction" : "' // trim(adjustl(self%activationFunction_%string())) // '"'), &
+      string_t(indent // indent // '"usingSkipConnections" : "' // trim(adjustl(self%usingSkipConnections_%string())) // '"'), &
+      string_t(indent // '},') &
+    ]
+  end procedure
+
+  module procedure equals
+    lhs_equals_rhs = &
+      lhs%modelName_ == rhs%modelName_ .and. &
+      lhs%modelAuthor_ == rhs%modelAuthor_ .and. &
+      lhs%compilationDate_ == rhs%compilationDate_ .and. &
+      lhs%activationFunction_ == rhs%activationFunction_ .and. &
+      lhs%usingSkipConnections_ == rhs%usingSkipConnections_
+  end procedure 
+
+end submodule metadata_s

--- a/src/inference_engine/metadata_s.f90
+++ b/src/inference_engine/metadata_s.f90
@@ -49,10 +49,10 @@ contains
 
     lines = [ &
       string_t(indent // '"metadata": {'), &
-      string_t(indent // indent // '"modelName" : "'  // trim(adjustl(self%modelName_%string()))  // '"' ), &
-      string_t(indent // indent // '"modelAuthor" : "'  // trim(adjustl(self%modelAuthor_%string())) // '"' ), &
-      string_t(indent // indent // '"compilationDate" : "' // trim(adjustl(self%compilationDate_%string())) // '"'), &
-      string_t(indent // indent // '"activationFunction" : "' // trim(adjustl(self%activationFunction_%string())) // '"'), &
+      string_t(indent // indent // '"modelName" : "'  // trim(adjustl(self%modelName_%string()))  // '",' ), &
+      string_t(indent // indent // '"modelAuthor" : "'  // trim(adjustl(self%modelAuthor_%string())) // '",' ), &
+      string_t(indent // indent // '"compilationDate" : "' // trim(adjustl(self%compilationDate_%string())) // '",'), &
+      string_t(indent // indent // '"activationFunction" : "' // trim(adjustl(self%activationFunction_%string())) // '",'), &
       string_t(indent // indent // '"usingSkipConnections" : "' // trim(adjustl(self%usingSkipConnections_%string())) // '"'), &
       string_t(indent // '},') &
     ]

--- a/src/inference_engine/metadata_s.f90
+++ b/src/inference_engine/metadata_s.f90
@@ -4,6 +4,10 @@ submodule(metadata_m) metadata_s
 
 contains
 
+  module procedure strings
+    components = [self%modelName_, self%modelAuthor_, self%compilationDate_, self%activationFunction_, self%usingSkipConnections_]
+  end procedure 
+  
   module procedure from_components
     metadata%modelName_ = modelName
     metadata%modelAuthor_ = modelAuthor

--- a/src/inference_engine/neuron_m.f90
+++ b/src/inference_engine/neuron_m.f90
@@ -15,6 +15,7 @@ module neuron_m
     real(rkind) bias_
     type(neuron_t), allocatable :: next
   contains
+    procedure :: to_json
     procedure :: weights
     procedure :: bias
     procedure :: next_allocated
@@ -24,7 +25,7 @@ module neuron_m
 
   interface neuron_t
 
-    pure recursive module function construct(neuron_lines, start) result(neuron)
+    pure recursive module function from_json(neuron_lines, start) result(neuron)
       !! construct linked list of neuron_t objects from an array of JSON-formatted text lines
       implicit none
       type(string_t), intent(in) :: neuron_lines(:)
@@ -32,9 +33,22 @@ module neuron_m
       type(neuron_t) neuron
     end function
 
+    pure module function from_components(weights, bias) result(neuron)
+      !! construct single neuron_t object from an array of weights and a bias
+      real(rkind), intent(in) :: weights(:)
+      real(rkind), intent(in) :: bias
+      type(neuron_t) neuron
+    end function
+
   end interface
 
   interface
+
+    pure module function to_json(self) result(lines)
+      implicit none
+      class(neuron_t), intent(in) :: self
+      type(string_t), allocatable :: lines(:)
+    end function
 
     module function weights(self) result(my_weights)
       implicit none

--- a/src/inference_engine/tensor_range_s.f90
+++ b/src/inference_engine/tensor_range_s.f90
@@ -22,7 +22,7 @@ contains
     tensor_range_key_found = .false.
 
     do l=1,size(lines)
-      if (lines(l)%get_json_key() == "tensor_range") then
+      if (lines(l)%get_json_key() == "inputs_range" .or. lines(l)%get_json_key() == "outputs_range") then
         tensor_range_key_found = .true.
         tensor_range%layer_  = lines(l+1)%get_json_value(key=string_t("layer"), mold=string_t(""))
         tensor_range%minima_ = lines(l+2)%get_json_value(key=string_t("minima"), mold=[0.])
@@ -62,13 +62,17 @@ contains
     allocate(character(len=size(self%maxima_)*(characters_per_value+1)-1)::maxima_string)
     write(minima_string, fmt = csv_format) self%minima_
     write(maxima_string, fmt = csv_format) self%maxima_
-    lines = [ &
-      string_t(indent // '"tensor_range": {'), &
-      string_t(indent // '  "layer": "' // trim(adjustl(self%layer_)) // '",'), &
-      string_t(indent // '  "minima": [' // trim(adjustl(minima_string)) // '],'), & 
-      string_t(indent // '  "maxima": [' // trim(adjustl(maxima_string)) // ']'), &
-      string_t(indent // '}') &
-    ]
+    block 
+      character(len=:), allocatable :: layer
+      layer = trim(adjustl(self%layer_))
+      lines = [ &
+        string_t(indent // '"'//layer//'_range": {'), &
+        string_t(indent // '  "layer": "' // layer // '",'), &
+        string_t(indent // '  "minima": [' // trim(adjustl(minima_string)) // '],'), & 
+        string_t(indent // '  "maxima": [' // trim(adjustl(maxima_string)) // ']'), &
+        string_t(indent // '}') &
+      ]
+    end block
   end procedure
 
   module procedure map_to_training_range

--- a/src/inference_engine/trainable_engine_m.F90
+++ b/src/inference_engine/trainable_engine_m.F90
@@ -6,6 +6,7 @@ module trainable_engine_m
   use inference_engine_m_, only : inference_engine_t
   use differentiable_activation_strategy_m, only : differentiable_activation_strategy_t
   use kind_parameters_m, only : rkind
+  use metadata_m, only : metadata_t
   use tensor_m, only :  tensor_t
   use tensor_range_m, only :  tensor_range_t
   use mini_batch_m, only : mini_batch_t
@@ -19,7 +20,7 @@ module trainable_engine_m
     !! Encapsulate the information needed to perform training
     private
     type(tensor_range_t) input_range_, output_range_
-    type(string_t), allocatable :: metadata_(:)
+    type(metadata_t) metadata_
     real(rkind), allocatable :: w(:,:,:) ! weights
     real(rkind), allocatable :: b(:,:) ! biases
     integer, allocatable :: n(:) ! nodes per layer

--- a/src/inference_engine/trainable_engine_s.F90
+++ b/src/inference_engine/trainable_engine_s.F90
@@ -36,8 +36,7 @@ contains
 #endif
       trainable_engine%input_range_ = exchange%input_range_
       trainable_engine%output_range_ = exchange%output_range_
-      trainable_engine%metadata_ = &
-        metadata_t(exchange%metadata_(1),exchange%metadata_(2),exchange%metadata_(3),exchange%metadata_(4),exchange%metadata_(5))
+      trainable_engine%metadata_ = exchange%metadata_
       trainable_engine%w = exchange%weights_
       trainable_engine%b = exchange%biases_
       trainable_engine%n = exchange%nodes_

--- a/src/inference_engine/trainable_engine_s.F90
+++ b/src/inference_engine/trainable_engine_s.F90
@@ -36,7 +36,8 @@ contains
 #endif
       trainable_engine%input_range_ = exchange%input_range_
       trainable_engine%output_range_ = exchange%output_range_
-      trainable_engine%metadata_ = exchange%metadata_
+      trainable_engine%metadata_ = &
+        metadata_t(exchange%metadata_(1),exchange%metadata_(2),exchange%metadata_(3),exchange%metadata_(4),exchange%metadata_(5))
       trainable_engine%w = exchange%weights_
       trainable_engine%b = exchange%biases_
       trainable_engine%n = exchange%nodes_
@@ -262,8 +263,7 @@ contains
   module procedure construct_from_padded_arrays
 #endif
 
-
-    trainable_engine%metadata_ = metadata
+    trainable_engine%metadata_ = metadata_t(metadata(1),metadata(2),metadata(3),metadata(4),metadata(5))
     trainable_engine%n = nodes
     trainable_engine%w = weights
     trainable_engine%b = biases
@@ -296,7 +296,8 @@ contains
     ! assignment-stmt disallows the procedure from being pure because it might
     ! deallocate polymorphic allocatable subcomponent `activation_strategy_`
     ! TODO: consider how this affects design
-    inference_engine = inference_engine_t(self%metadata_, self%w, self%b, self%n, self%input_range_, self%output_range_)
+    inference_engine = inference_engine_t( &
+      self%metadata_%strings(), self%w, self%b, self%n, self%input_range_, self%output_range_)
   end procedure
 
   module procedure perturbed_identity_network

--- a/src/inference_engine_m.f90
+++ b/src/inference_engine_m.f90
@@ -8,6 +8,7 @@ module inference_engine_m
  use input_output_pair_m, only : input_output_pair_t, shuffle
  use inference_engine_m_, only : inference_engine_t, difference_t, infer
  use kind_parameters_m, only : rkind
+ use metadata_m, only : metadata_t
  use mini_batch_m, only : mini_batch_t
  use network_configuration_m, only : network_configuration_t
  use gelu_m, only : gelu_t

--- a/test/main.F90
+++ b/test/main.F90
@@ -4,6 +4,7 @@ program main
   use inference_engine_test_m, only : inference_engine_test_t
   use asymmetric_engine_test_m, only : asymmetric_engine_test_t
   use trainable_engine_test_m, only : trainable_engine_test_t
+  use metadata_test_m, only : metadata_test_t
   use hyperparameters_test_m, only : hyperparameters_test_t
   use network_configuration_test_m, only : network_configuration_test_t
   use training_configuration_test_m, only : training_configuration_test_t
@@ -15,6 +16,7 @@ program main
   type(asymmetric_engine_test_t) asymmetric_engine_test
   type(trainable_engine_test_t) trainable_engine_test
   type(hyperparameters_test_t) hyperparameters_test
+  type(metadata_test_t) metadata_test
   type(network_configuration_test_t) network_configuration_test
   type(training_configuration_test_t) training_configuration_test
   type(tensor_range_test_t) tensor_range_test
@@ -39,6 +41,7 @@ program main
   call random_init(repeatable=.true.,image_distinct=.true.)
   call hyperparameters_test%report(passes, tests)
   call network_configuration_test%report(passes, tests)
+  call metadata_test%report(passes, tests)
   call training_configuration_test%report(passes, tests)
   call tensor_range_test%report(passes, tests)
   call asymmetric_engine_test%report(passes, tests)

--- a/test/metadata_test_m.F90
+++ b/test/metadata_test_m.F90
@@ -1,0 +1,94 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+module metadata_test_m
+  !! Test metadata_t object I/O and construction
+
+  ! External dependencies
+  use inference_engine_m, only : metadata_t
+  use julienne_m, only : test_t, test_result_t, test_description_t, test_description_substring, string_t
+#ifdef __GFORTRAN__
+  use julienne_m, only : test_function_i
+#endif
+
+  ! Internal dependencies
+  use metadata_m, only : metadata_t
+
+  implicit none
+
+  private
+  public :: metadata_test_t
+
+  type, extends(test_t) :: metadata_test_t
+  contains
+    procedure, nopass :: subject
+    procedure, nopass :: results
+  end type
+
+contains
+
+  pure function subject() result(specimen)
+    character(len=:), allocatable :: specimen
+    specimen = "A metadata_t object"
+  end function
+
+  function results() result(test_results)
+    type(test_description_t), allocatable :: test_descriptions(:)
+    type(test_result_t), allocatable :: test_results(:)
+
+#ifndef __GFORTRAN__
+    test_descriptions = [ & 
+      test_description_t( &
+        string_t("component-wise construction followed by conversion to and from JSON"), &
+        write_then_read_metadata) &
+    ]
+#else
+    procedure(test_function_i), pointer :: check_write_then_read_ptr
+    check_write_then_read_ptr => write_then_read_metadata
+
+    test_descriptions = [ &
+      test_description_t( &
+        string_t("component-wise construction followed by conversion to and from JSON"), &
+        check_write_then_read_ptr) &
+    ]
+#endif
+    associate( &
+      substring_in_subject => index(subject(), test_description_substring) /= 0, &
+      substring_in_description => test_descriptions%contains_text(string_t(test_description_substring)) &
+    )
+      test_descriptions = pack(test_descriptions, substring_in_subject .or. substring_in_description)
+    end associate
+    test_results = test_descriptions%run()
+  end function
+
+  function write_then_read_metadata() result(test_passes)
+    logical test_passes
+#ifdef _CRAYFTN
+    type(metadata_t) :: metadata, from_json
+    metadata = metadata_t( &
+      modelName = string_t("Metadata Unit Test"), &
+      modelAuthor = string_t("Julienne"), &
+      compilationDate = string_t("2024-06-27"), &
+      activationFunction = string_t("sigmoid"), &
+      usingSkipConnections = string_t("false") &
+    ) &
+    from_json = metadata_t(metadata%to_json())
+#else
+    associate(metadata => &
+      metadata_t( &
+        modelName = string_t("Metadata Unit Test"), &
+        modelAuthor = string_t("Julienne"), &
+        compilationDate = string_t("2024-06-27"), &
+        activationFunction = string_t("sigmoid"), &
+        usingSkipConnections = string_t("false") &
+      ) &
+    )
+      associate(from_json => metadata_t(metadata%to_json()))
+#endif
+        test_passes = metadata == from_json
+#ifndef _CRAYFTN
+      end associate
+    end associate
+#endif
+  end function
+
+end module metadata_test_m

--- a/test/tensor_range_test_m.F90
+++ b/test/tensor_range_test_m.F90
@@ -65,9 +65,9 @@ contains
     type(file_t) :: json_file
 #ifdef _CRAYFTN
     type(tensor_range_t) :: tensor_range
-    tensor_range = tensor_range_t(layer="input", minima=[-1., 0., 1.], maxima=[1., 2., 4.])
+    tensor_range = tensor_range_t(layer="inputs", minima=[-1., 0., 1.], maxima=[1., 2., 4.])
 #else
-    associate(tensor_range => tensor_range_t(layer="input", minima=[-1., 0., 1.], maxima=[1., 2., 4.]))
+    associate(tensor_range => tensor_range_t(layer="inputs", minima=[-1., 0., 1.], maxima=[1., 2., 4.]))
 #endif
       associate(from_json => tensor_range_t(tensor_range%to_json()))
         test_passes = tensor_range == from_json


### PR DESCRIPTION
With this pull request, executing
```
fpm run --example read-query-infer -- --input-file uneven.json
```
gives the desired result of producing outputs identically equal to the corresponding inputs on a network with varying hidden-layer widths such as the attached file [uneven.json.gz](https://github.com/user-attachments/files/16059628/uneven.json.gz) when uncompressed.  The new `example/read-and-query.f90` program generates random inputs.  An example execution of the above line produces the output
```
Project is up to date
 Reading an inference_engine_t object from the same JSON file 'uneven.json'.
 Querying the new inference_engine_t object for several properties:
 Activation function: relu
 Number of outputs:           2
 Number of inputs:           2
 Nodes per layer:           2           2           3           2
 Performing inference:
 Inputs                 |       Outputs  
  6.7125     0.12062    |    6.7125      1.0000    
  4.4105      5.5553    |    4.4105      5.5553    
  2.8614      8.4003    |    2.8614      8.4003   
```