### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/example/learn-saturated-mixing-ratio.F90
+++ b/example/learn-saturated-mixing-ratio.F90
@@ -174,7 +174,7 @@ contains
     type(trainable_engine_t) trainable_engine
     real, intent(in) :: perturbation_magnitude
     integer, intent(in)  :: n(:)
-    integer j, k, l
+    integer k, l
     real, allocatable :: identity(:,:,:), w_harvest(:,:,:), b_harvest(:,:)
 
     associate(n_max => maxval(n), layers => size(n))
@@ -224,6 +224,8 @@ contains
         lines = plot_file%lines()
         last_line = lines(size(lines))%string()
         read(last_line,*, iostat=io_status) previous_epoch, cost, previous_clock
+        associate(eliminate_unreferenced_variable_warning => cost)
+        end associate
         if ((io_status /= io_success .and. last_line == header) .or. len(trim(last_line))==0) then
           previous_epoch = 0
           previous_clock = 0

--- a/fpm.toml
+++ b/fpm.toml
@@ -6,4 +6,4 @@ maintainer = "rouson@lbl.gov"
 
 [dependencies]
 assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.7.0"}
-julienne = {git = "https://github.com/sourceryinstitute/julienne", tag = "1.0.0"}
+julienne = {git = "https://github.com/berkeleylab/julienne"}

--- a/src/inference_engine/inference_engine_m_.f90
+++ b/src/inference_engine/inference_engine_m_.f90
@@ -9,7 +9,6 @@ module inference_engine_m_
   use metadata_m, only : metadata_t
   use tensor_m, only : tensor_t
   use tensor_range_m, only : tensor_range_t
-  use differentiable_activation_strategy_m, only :differentiable_activation_strategy_t
   implicit none
 
   private

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -44,7 +44,7 @@ contains
 
     real(rkind), allocatable :: a(:,:)
     integer, parameter :: input_layer = 0
-    integer k, l
+    integer l
 
     call assert_consistency(self)
 

--- a/src/inference_engine/inference_engine_s.F90
+++ b/src/inference_engine/inference_engine_s.F90
@@ -195,7 +195,6 @@ contains
     type(string_t), allocatable :: lines(:)
     type(tensor_range_t) input_range, output_range
     type(layer_t) hidden_layers, output_layer
-    real(rkind), allocatable :: hidden_weights(:,:,:)
     character(len=:), allocatable :: justified_line
     integer l
 #ifdef _CRAYFTN

--- a/src/inference_engine/input_output_pair_m.f90
+++ b/src/inference_engine/input_output_pair_m.f90
@@ -1,7 +1,6 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 module input_output_pair_m
-  use kind_parameters_m, only : rkind
   use tensor_m, only : tensor_t
   implicit none
 

--- a/src/inference_engine/input_output_pair_s.f90
+++ b/src/inference_engine/input_output_pair_s.f90
@@ -1,7 +1,6 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(input_output_pair_m) input_output_pair_s
-  use assert_m, only : assert
   implicit none
 
 contains

--- a/src/inference_engine/layer_m.f90
+++ b/src/inference_engine/layer_m.f90
@@ -3,7 +3,6 @@
 module layer_m
   use neuron_m, only : neuron_t
   use julienne_string_m, only : string_t
-  use kind_parameters_m, only : rkind
   use inference_engine_m_, only : inference_engine_t
   use tensor_range_m, only :  tensor_range_t
   implicit none

--- a/src/inference_engine/layer_s.f90
+++ b/src/inference_engine/layer_s.f90
@@ -3,6 +3,7 @@
 submodule(layer_m) layer_s
   use assert_m, only : assert
   use intrinsic_array_m, only : intrinsic_array_t
+  use kind_parameters_m, only : rkind
   implicit none
 
 contains

--- a/src/inference_engine/layer_s.f90
+++ b/src/inference_engine/layer_s.f90
@@ -2,7 +2,6 @@
 ! Terms of use are as specified in LICENSE.txt
 submodule(layer_m) layer_s
   use assert_m, only : assert
-  use intrinsic_array_m, only : intrinsic_array_t
   use kind_parameters_m, only : rkind
   implicit none
 

--- a/src/inference_engine/layer_s.f90
+++ b/src/inference_engine/layer_s.f90
@@ -172,7 +172,11 @@ contains
   end procedure
 
   module procedure next_pointer
-    next_ptr => self%next
+    if (allocated(self%next)) then
+      next_ptr => self%next
+    else
+      next_ptr => null()
+    end if
   end procedure
 
 end submodule layer_s

--- a/src/inference_engine/mini_batch_m.f90
+++ b/src/inference_engine/mini_batch_m.f90
@@ -2,7 +2,6 @@
 ! Terms of use are as specified in LICENSE.txt
 module mini_batch_m
   use input_output_pair_m, only : input_output_pair_t
-  use kind_parameters_m, only : rkind
   implicit none
 
   private

--- a/src/inference_engine/neuron_s.f90
+++ b/src/inference_engine/neuron_s.f90
@@ -80,7 +80,11 @@ contains
   end procedure
 
   module procedure next_pointer
-    next_ptr => self%next
+    if (allocated(self%next)) then
+      next_ptr => self%next
+    else
+      next_ptr => null()
+    end if
   end procedure
 
   module procedure num_inputs

--- a/src/inference_engine/tensor_range_m.f90
+++ b/src/inference_engine/tensor_range_m.f90
@@ -3,7 +3,6 @@
 module tensor_range_m
   use tensor_m, only : tensor_t
   use julienne_m, only : string_t
-  use kind_parameters_m, only : rkind
   implicit none
   
   private


### PR DESCRIPTION
This PR eliminates all but two warnings generated by compiling the single-source-file version of Inference-Engine with the NAG compiler.  The two remaining warnings are the subject of a just-submitted compiler bug report.