### PR TITLE
Fix GELU & sigmoid activation precision

### DIFF
--- a/src/inference_engine/gelu_s.f90
+++ b/src/inference_engine/gelu_s.f90
@@ -7,9 +7,9 @@ submodule(gelu_m) gelu_s
   real, parameter :: half = 0.5, two = 2.D0
   real, parameter :: sqrt_2_pi = sqrt(2*pi), sqrt_2 = sqrt(2.)
 
-  real, parameter :: pi_dp = 3.141592653589793D0
-  real, parameter :: half_dp = 0.5D0, two_dp = 2.D0
-  real, parameter :: sqrt_2_pi_dp = sqrt(two_dp*pi_dp), sqrt_2_dp = sqrt(2.D0)
+  double precision, parameter :: pi_dp = 3.141592653589793D0
+  double precision, parameter :: half_dp = 0.5D0, two_dp = 2.D0
+  double precision, parameter :: sqrt_2_pi_dp = sqrt(two_dp*pi_dp), sqrt_2_dp = sqrt(2.D0)
 
 contains
 

--- a/src/inference_engine/sigmoid_s.f90
+++ b/src/inference_engine/sigmoid_s.f90
@@ -10,7 +10,7 @@ contains
     end procedure
 
     module procedure double_precision_activation
-      y =  1./(1.+exp(-x))
+      y =  1.D0/(1.D0+exp(-x))
     end procedure
 
     module procedure default_real_activation_derivative
@@ -18,7 +18,7 @@ contains
     end procedure
 
     module procedure double_precision_activation_derivative
-      y =  exp(-x)/(1.+exp(-x))**2
+      y =  exp(-x)/(1.D0+exp(-x))**2
     end procedure
 
     module procedure function_name


### PR DESCRIPTION
This PR fixes several compile-time constants to ensure that the double-precision versions of the GELU and sigmoid activation functions use double-precision throughout their evaluations.