### PR TITLE
Move dynamic stack allocations outside `do concurrent`

### DIFF
--- a/src/fiats/neural_network_s.F90
+++ b/src/fiats/neural_network_s.F90
@@ -926,6 +926,9 @@ contains
               block
                 real reduce_dcdb(size(dcdb,1),size(dcdb,2),mini_batch_size)
                 real reduce_dcdw(size(dcdw,1),size(dcdw,2),size(dcdw,3),mini_batch_size)
+                real a(maxval(self%nodes_), input_layer:output_layer) ! Activations
+                real z(size(b,1),size(b,2)), delta(size(b,1),size(b,2))
+
                 reduce_dcdb = 0.
                 reduce_dcdw = 0.
               
@@ -934,9 +937,6 @@ contains
 
                   iteration: &
                   block
-
-                    real a(maxval(self%nodes_), input_layer:output_layer) ! Activations
-                    real z(size(b,1),size(b,2)), delta(size(b,1),size(b,2))
 #endif
 
                     a(1:self%num_inputs(), input_layer) = inputs(pair)%values()


### PR DESCRIPTION
Dynamic stack allocations are those allocs where memory is allocated on the stack (i.e. inside a function or proceure) with a size not known at compile time.

Even though this is legal both at compile and run-times for the CPU, on the GPU this is not supported.

Therefore, this PR removes an instance of such allocations (this is the only instance I came across so far while compiling for the GPU).