### PR TITLE
feat(training_config): expand tensor components

### DIFF
--- a/demo/training_configuration.json
+++ b/demo/training_configuration.json
@@ -6,11 +6,11 @@
      },
      "network configuration": {
          "skip connections" : false,
-         "nodes per layer" : [7,32,32,32,5],
+         "nodes per layer" : [11,32,32,32,9],
          "activation function" : "sigmoid"
      },
      "tensor names": {
-         "inputs"  : ["potential_temperature","qv", "qc", "qr", "qs", "pressure", "temperature"],
-         "outputs" : ["potential_temperature","qv", "qc", "qr", "qs"]
+         "inputs"  : ["potential_temperature","qv", "qc", "qr", "qs", "pressure", "temperature", "ni", "nr", "qi", "qg"],
+         "outputs" : ["potential_temperature","qv", "qc", "qr", "qs", "ni", "nr", "qi", "qg"]
      }
  }

--- a/demo/training_data_files.json
+++ b/demo/training_data_files.json
@@ -6,3 +6,8 @@
          "infixes" : ["450", "500"]
      }
  }
+
+training_input-image-_450.nc
+training_output-image-_450.nc
+training_input-image-_500.nc
+training_output-image-_500.nc


### PR DESCRIPTION
This commit updates the "tensor names" field in the `demo/training_configuration.json` file to add additional the following input/output variables for training: `ni`, `nr`, `qi`, and `qg`.