### PR TITLE
CI: Switch containers to a stable flang 22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
       fail-fast: true
-    container: gmao/llvm-flang:latest
+    container: phhargrove/llvm-flang:22.1.0-latest
     env:
-      FC: flang-new
+      FC: flang
       CC: clang
 
     steps:
@@ -31,4 +31,4 @@ jobs:
         $CC --version
         export FPM_FC=$FC
         export FPM_CC=$CC
-        fpm test --flag "-mmlir -allow-assumed-rank -O3"
+        fpm test --profile release


### PR DESCRIPTION
Fix CI, by switching from a broken container to a stable one.

Here I've assumed you want to continue with just the latest Flang on Linux for Fiats and not expand out to more platforms.